### PR TITLE
Show sleep entries in feed

### DIFF
--- a/HealthHelper/AppShell.xaml.cs
+++ b/HealthHelper/AppShell.xaml.cs
@@ -10,6 +10,7 @@ public partial class AppShell : Shell
 
         Routing.RegisterRoute(nameof(SettingsPage), typeof(SettingsPage));
         Routing.RegisterRoute(nameof(MealDetailPage), typeof(MealDetailPage));
+        Routing.RegisterRoute(nameof(SleepDetailPage), typeof(SleepDetailPage));
         Routing.RegisterRoute(nameof(DailySummaryPage), typeof(DailySummaryPage));
         Routing.RegisterRoute(nameof(ExerciseDetailPage), typeof(ExerciseDetailPage));
         Routing.RegisterRoute(nameof(ShareEntryPage), typeof(ShareEntryPage));

--- a/HealthHelper/MauiProgram.cs
+++ b/HealthHelper/MauiProgram.cs
@@ -76,6 +76,8 @@ public static class MauiProgram
 
         builder.Services.AddTransient<MealDetailViewModel>();
         builder.Services.AddTransient<MealDetailPage>();
+        builder.Services.AddTransient<SleepDetailViewModel>();
+        builder.Services.AddTransient<SleepDetailPage>();
 
         builder.Services.AddTransient<DailySummaryViewModel>();
         builder.Services.AddTransient<DailySummaryPage>();

--- a/HealthHelper/Models/SleepEntry.cs
+++ b/HealthHelper/Models/SleepEntry.cs
@@ -1,0 +1,27 @@
+namespace HealthHelper.Models;
+
+public partial class SleepEntry : TrackedEntryCard
+{
+    public SleepEntry(
+        int entryId,
+        string previewPath,
+        string? description,
+        DateTime capturedAtUtc,
+        string? capturedAtTimeZoneId,
+        int? capturedAtOffsetMinutes,
+        ProcessingStatus processingStatus)
+        : base(
+            entryId,
+            EntryType.Sleep,
+            capturedAtUtc,
+            capturedAtTimeZoneId,
+            capturedAtOffsetMinutes,
+            processingStatus)
+    {
+        PreviewPath = previewPath;
+        Description = description;
+    }
+
+    public string PreviewPath { get; }
+    public string? Description { get; }
+}

--- a/HealthHelper/PageModels/SleepDetailViewModel.cs
+++ b/HealthHelper/PageModels/SleepDetailViewModel.cs
@@ -1,0 +1,227 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Text;
+using System.Text.Json;
+using System.Threading.Tasks;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using HealthHelper.Data;
+using HealthHelper.Models;
+using Microsoft.Extensions.Logging;
+using Microsoft.Maui.ApplicationModel;
+using Microsoft.Maui.Storage;
+
+namespace HealthHelper.PageModels;
+
+[QueryProperty(nameof(Sleep), "Sleep")]
+public partial class SleepDetailViewModel : ObservableObject
+{
+    private readonly ITrackedEntryRepository _trackedEntryRepository;
+    private readonly IEntryAnalysisRepository _entryAnalysisRepository;
+    private readonly ILogger<SleepDetailViewModel> _logger;
+
+    [ObservableProperty]
+    private SleepEntry? sleep;
+
+    [ObservableProperty]
+    private string analysisText = "No analysis available for this sleep entry.";
+
+    public SleepDetailViewModel(
+        ITrackedEntryRepository trackedEntryRepository,
+        IEntryAnalysisRepository entryAnalysisRepository,
+        ILogger<SleepDetailViewModel> logger)
+    {
+        _trackedEntryRepository = trackedEntryRepository;
+        _entryAnalysisRepository = entryAnalysisRepository;
+        _logger = logger;
+    }
+
+    partial void OnSleepChanged(SleepEntry? value)
+    {
+        _ = LoadAnalysisAsync();
+    }
+
+    [RelayCommand]
+    private async Task DeleteAsync()
+    {
+        if (Sleep is null)
+        {
+            _logger.LogWarning("Delete command invoked without a selected sleep entry.");
+            return;
+        }
+
+        try
+        {
+            _logger.LogInformation("Deleting sleep entry {EntryId}.", Sleep.EntryId);
+
+            var pathsToDelete = await ResolveFilePathsAsync(Sleep).ConfigureAwait(false);
+            foreach (var path in pathsToDelete)
+            {
+                TryDeleteFile(path, Sleep.EntryId);
+            }
+
+            await _trackedEntryRepository.DeleteAsync(Sleep.EntryId).ConfigureAwait(false);
+            await MainThread.InvokeOnMainThreadAsync(() => Shell.Current.GoToAsync(".."));
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to delete sleep entry {EntryId}.", Sleep.EntryId);
+            await MainThread.InvokeOnMainThreadAsync(() => Shell.Current.DisplayAlertAsync("Delete failed", "We couldn't delete this sleep entry. Try again later.", "OK"));
+        }
+    }
+
+    private async Task<HashSet<string>> ResolveFilePathsAsync(SleepEntry sleepEntry)
+    {
+        var paths = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        if (!string.IsNullOrWhiteSpace(sleepEntry.PreviewPath))
+        {
+            paths.Add(sleepEntry.PreviewPath);
+        }
+
+        try
+        {
+            var trackedEntry = await _trackedEntryRepository.GetByIdAsync(sleepEntry.EntryId).ConfigureAwait(false);
+            if (trackedEntry is not null)
+            {
+                if (!string.IsNullOrWhiteSpace(trackedEntry.BlobPath))
+                {
+                    var absolute = Path.Combine(FileSystem.AppDataDirectory, trackedEntry.BlobPath);
+                    paths.Add(absolute);
+                }
+
+                if (trackedEntry.Payload is PendingEntryPayload pendingPayload && !string.IsNullOrWhiteSpace(pendingPayload.PreviewBlobPath))
+                {
+                    var previewAbsolute = Path.Combine(FileSystem.AppDataDirectory, pendingPayload.PreviewBlobPath);
+                    paths.Add(previewAbsolute);
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Unable to resolve persisted file paths for sleep entry {EntryId}.", sleepEntry.EntryId);
+        }
+
+        return paths;
+    }
+
+    private void TryDeleteFile(string path, int entryId)
+    {
+        if (string.IsNullOrWhiteSpace(path))
+        {
+            return;
+        }
+
+        try
+        {
+            if (File.Exists(path))
+            {
+                File.Delete(path);
+                _logger.LogDebug("Deleted file {Path} for sleep entry {EntryId}.", path, entryId);
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to delete file {Path} for sleep entry {EntryId}.", path, entryId);
+        }
+    }
+
+    private async Task LoadAnalysisAsync()
+    {
+        if (Sleep is null)
+        {
+            return;
+        }
+
+        try
+        {
+            _logger.LogDebug("Loading sleep analysis for entry {EntryId}.", Sleep.EntryId);
+            var analysis = await _entryAnalysisRepository.GetByTrackedEntryIdAsync(Sleep.EntryId).ConfigureAwait(false);
+            if (analysis is null)
+            {
+                AnalysisText = "No analysis available for this sleep entry.";
+                return;
+            }
+
+            AnalysisText = FormatAnalysis(analysis);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to load sleep analysis for entry {EntryId}.", Sleep.EntryId);
+            AnalysisText = "We couldn't load the analysis for this sleep entry.";
+        }
+    }
+
+    private static string FormatAnalysis(EntryAnalysis analysis)
+    {
+        try
+        {
+            var unified = JsonSerializer.Deserialize<UnifiedAnalysisResult>(analysis.InsightsJson);
+            if (unified is null)
+            {
+                return analysis.InsightsJson;
+            }
+
+            if (!string.Equals(unified.EntryType, "Sleep", StringComparison.OrdinalIgnoreCase) || unified.SleepAnalysis is null)
+            {
+                return "This entry was classified as a different type. Sleep-specific analysis is not available.";
+            }
+
+            var sleep = unified.SleepAnalysis;
+            var builder = new StringBuilder();
+
+            if (unified.Confidence > 0)
+            {
+                builder.AppendLine($"Confidence: {(unified.Confidence * 100):0.#}%");
+                builder.AppendLine();
+            }
+
+            if (sleep.DurationHours is double duration)
+            {
+                builder.AppendLine($"Duration: {duration:0.#} hours");
+            }
+
+            if (sleep.SleepScore is double score)
+            {
+                builder.AppendLine($"Sleep Score: {score:0.#}/100");
+            }
+
+            if (!string.IsNullOrWhiteSpace(sleep.QualitySummary))
+            {
+                builder.AppendLine();
+                builder.AppendLine(sleep.QualitySummary);
+            }
+
+            if (sleep.EnvironmentNotes is { Count: > 0 })
+            {
+                builder.AppendLine();
+                builder.AppendLine("Environment notes:");
+                foreach (var note in sleep.EnvironmentNotes)
+                {
+                    builder.AppendLine($"• {note}");
+                }
+            }
+
+            if (sleep.Recommendations is { Count: > 0 })
+            {
+                builder.AppendLine();
+                builder.AppendLine("Recommendations:");
+                foreach (var recommendation in sleep.Recommendations)
+                {
+                    builder.AppendLine($"• {recommendation}");
+                }
+            }
+
+            var content = builder.ToString().Trim();
+            return string.IsNullOrWhiteSpace(content)
+                ? "No additional sleep insights were provided."
+                : content;
+        }
+        catch (JsonException)
+        {
+            return analysis.InsightsJson;
+        }
+    }
+}

--- a/HealthHelper/Pages/MainPage.xaml
+++ b/HealthHelper/Pages/MainPage.xaml
@@ -106,12 +106,74 @@
                                 <Label Text="Analysis Skipped"
                                        TextColor="Gray"
                                        FontAttributes="Bold"
+                           IsVisible="{Binding ProcessingStatus, Converter={StaticResource IsSkippedConverter}}" />
+                        </VerticalStackLayout>
+                    </Grid>
+
+                    <VerticalStackLayout Padding="16" VerticalOptions="Start" Grid.Row="1" Spacing="4">
+                        <Label Text="Exercise entry"
+                               Style="{StaticResource Body2Strong}" />
+                        <Label Text="{Binding Description}"
+                               Style="{StaticResource Body1}" />
+                        <Label Text="{Binding LocalCapturedAt, StringFormat='Captured {0:MMM d, h:mm tt}'}"
+                               Style="{StaticResource Caption1}" />
+                            <Label Text="Analysis Skipped"
+                                   TextColor="{StaticResource Gray500}"
+                                   FontAttributes="Bold"
+                                   IsVisible="{Binding ProcessingStatus, Converter={StaticResource IsSkippedConverter}}" />
+                            <Label Text="Processing..."
+                                   TextColor="{StaticResource Gray500}"
+                                   FontAttributes="Bold"
+                                   IsVisible="{Binding ProcessingStatus, Converter={StaticResource IsProcessingConverter}}" />
+                            <Label Text="Failed"
+                                   TextColor="{StaticResource Error}"
+                                   FontAttributes="Bold"
+                           IsVisible="{Binding ProcessingStatus, Converter={StaticResource IsFailedConverter}}" />
+                        </VerticalStackLayout>
+                    </Grid>
+                </Border>
+            </DataTemplate>
+
+            <DataTemplate x:Key="SleepCardTemplate" x:DataType="models:SleepEntry">
+                <Border StrokeThickness="1"
+                        Stroke="{AppThemeBinding Light={StaticResource Gray200}, Dark={StaticResource Gray600}}"
+                        Padding="0"
+                        Margin="0,0,0,16"
+                        BackgroundColor="Transparent"
+                        StrokeShape="RoundRectangle 12,12,12,12">
+
+                    <Grid RowDefinitions="Auto,Auto" BackgroundColor="Transparent">
+                        <Image Source="{Binding PreviewPath}"
+                               Aspect="AspectFill"
+                               HeightRequest="220"
+                               SemanticProperties.Description="Sleep screenshot" />
+
+                        <Grid Grid.Row="0"
+                              BackgroundColor="#80000000"
+                              IsVisible="{Binding IsClickable, Converter={StaticResource InvertedBoolConverter}}">
+                            <VerticalStackLayout HorizontalOptions="Center"
+                                                 VerticalOptions="Center"
+                                                 Spacing="8">
+                                <ActivityIndicator IsRunning="True"
+                                                   Color="White"
+                                                   IsVisible="{Binding ProcessingStatus, Converter={StaticResource IsProcessingConverter}}" />
+                                <Label Text="Analyzing..."
+                                       TextColor="White"
+                                       FontAttributes="Bold"
+                                       IsVisible="{Binding ProcessingStatus, Converter={StaticResource IsProcessingConverter}}" />
+                                <Label Text="Analysis Failed - Tap to Retry"
+                                       TextColor="Orange"
+                                       FontAttributes="Bold"
+                                       IsVisible="{Binding ProcessingStatus, Converter={StaticResource IsFailedConverter}}" />
+                                <Label Text="Analysis Skipped"
+                                       TextColor="Gray"
+                                       FontAttributes="Bold"
                                        IsVisible="{Binding ProcessingStatus, Converter={StaticResource IsSkippedConverter}}" />
                             </VerticalStackLayout>
                         </Grid>
 
                         <VerticalStackLayout Padding="16" VerticalOptions="Start" Grid.Row="1" Spacing="4">
-                            <Label Text="Exercise entry"
+                            <Label Text="Sleep entry"
                                    Style="{StaticResource Body2Strong}" />
                             <Label Text="{Binding Description}"
                                    Style="{StaticResource Body1}" />
@@ -136,7 +198,8 @@
 
             <templates:EntryCardTemplateSelector x:Key="EntryCardTemplateSelector"
                                                  MealTemplate="{StaticResource MealCardTemplate}"
-                                                 ExerciseTemplate="{StaticResource ExerciseCardTemplate}" />
+                                                 ExerciseTemplate="{StaticResource ExerciseCardTemplate}"
+                                                 SleepTemplate="{StaticResource SleepCardTemplate}" />
         </ResourceDictionary>
     </ContentPage.Resources>
 

--- a/HealthHelper/Pages/SleepDetailPage.xaml
+++ b/HealthHelper/Pages/SleepDetailPage.xaml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:pageModels="clr-namespace:HealthHelper.PageModels"
+             x:Class="HealthHelper.Pages.SleepDetailPage"
+             x:DataType="pageModels:SleepDetailViewModel"
+             Title="Sleep Details">
+    <ScrollView>
+        <VerticalStackLayout Spacing="16" Padding="24">
+            <Image Source="{Binding Sleep.PreviewPath}"
+                   Aspect="AspectFit"
+                   HeightRequest="300"
+                   SemanticProperties.Description="Sleep screenshot" />
+
+            <Label Text="Sleep entry"
+                   Style="{StaticResource Headline}" />
+            <Label Text="{Binding Sleep.Description}"
+                   Style="{StaticResource Body1}" />
+            <Label Text="{Binding Sleep.LocalCapturedAt, StringFormat='Captured {0:MMM d, h:mm tt}'}"
+                   Style="{StaticResource Caption1}" />
+
+            <Label Text="Analysis"
+                   Style="{StaticResource Title2}"
+                   Margin="0,16,0,0" />
+            <Label Text="{Binding AnalysisText}"
+                   Style="{StaticResource Body1}" />
+
+            <Button Text="Delete"
+                    Command="{Binding DeleteCommand}"
+                    BackgroundColor="{StaticResource Error}"
+                    TextColor="{StaticResource OnError}"
+                    Margin="0,16,0,0" />
+        </VerticalStackLayout>
+    </ScrollView>
+</ContentPage>

--- a/HealthHelper/Pages/SleepDetailPage.xaml.cs
+++ b/HealthHelper/Pages/SleepDetailPage.xaml.cs
@@ -1,0 +1,12 @@
+using HealthHelper.PageModels;
+
+namespace HealthHelper.Pages;
+
+public partial class SleepDetailPage : ContentPage
+{
+    public SleepDetailPage(SleepDetailViewModel viewModel)
+    {
+        InitializeComponent();
+        BindingContext = viewModel;
+    }
+}

--- a/HealthHelper/Pages/Templates/EntryCardTemplateSelector.cs
+++ b/HealthHelper/Pages/Templates/EntryCardTemplateSelector.cs
@@ -7,6 +7,7 @@ public class EntryCardTemplateSelector : DataTemplateSelector
 {
     public DataTemplate? MealTemplate { get; set; }
     public DataTemplate? ExerciseTemplate { get; set; }
+    public DataTemplate? SleepTemplate { get; set; }
 
     protected override DataTemplate OnSelectTemplate(object item, BindableObject container)
     {
@@ -24,6 +25,12 @@ public class EntryCardTemplateSelector : DataTemplateSelector
                     throw new InvalidOperationException("ExerciseTemplate must be provided for EntryCardTemplateSelector.");
                 }
                 return ExerciseTemplate;
+            case SleepEntry:
+                if (SleepTemplate is null)
+                {
+                    throw new InvalidOperationException("SleepTemplate must be provided for EntryCardTemplateSelector.");
+                }
+                return SleepTemplate;
             default:
                 if (MealTemplate is not null)
                 {


### PR DESCRIPTION
## Summary
- surface sleep entries alongside meals and workouts in the day feed
- add a dedicated sleep card template and detail page to review analysis & delete captures

## Testing
- dotnet.exe build HealthHelper.slnx
- dotnet.exe test

Resolves #13