### PR TITLE
Fix: Use double for calorie/step fields to handle decimal LLM responses

### DIFF
--- a/WellnessWingman/Models/ExerciseAnalysisResult.cs
+++ b/WellnessWingman/Models/ExerciseAnalysisResult.cs
@@ -50,7 +50,7 @@ public class ExerciseMetrics
     public double? MaxHeartRate { get; set; }
 
     [JsonPropertyName("steps")]
-    public int? Steps { get; set; }
+    public double? Steps { get; set; }
 
     [JsonPropertyName("elevationGain")]
     public double? ElevationGain { get; set; }

--- a/WellnessWingman/Models/MealAnalysisResult.cs
+++ b/WellnessWingman/Models/MealAnalysisResult.cs
@@ -64,7 +64,7 @@ public class FoodItem
     /// Estimated calories for this item.
     /// </summary>
     [JsonPropertyName("calories")]
-    public int? Calories { get; set; }
+    public double? Calories { get; set; }
 
     /// <summary>
     /// Confidence in the detection of this food item (0.0 to 1.0).
@@ -79,7 +79,7 @@ public class NutritionEstimate
     /// Total estimated calories for the meal.
     /// </summary>
     [JsonPropertyName("totalCalories")]
-    public int? TotalCalories { get; set; }
+    public double? TotalCalories { get; set; }
 
     /// <summary>
     /// Protein in grams.


### PR DESCRIPTION
## Summary
- Fixed JSON deserialization failure when LLM returns decimal values for calories (e.g., `137.2`, `418.8`)
- Changed `int?` to `double?` for `FoodItem.Calories`, `NutritionEstimate.TotalCalories`, and `ExerciseMetrics.Steps`
- This was causing meal details to display raw JSON instead of formatted text, and preventing nutrition totals from being calculated

## Root Cause
When users provide specific weights in corrections (e.g., "40 grams of sausage"), the LLM calculates precise calorie values with decimals. The `int?` types caused `JsonSerializer.Deserialize<UnifiedAnalysisResult>` to throw a `JsonException`, which:
1. Made `FormatStructuredAnalysis` fall back to displaying raw JSON
2. Prevented `UnifiedAnalysisApplier.ApplyAsync` from being called, leaving entries with `EntryType = Unknown`

## Test plan
- [x] Build succeeds
- [x] All existing tests pass
- [x] Submit a correction with specific weights and verify formatted display
- [x] Verify nutrition totals include the corrected entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)