### PR TITLE
Make iOS and MacCatalyst targets conditional on OSX

### DIFF
--- a/WellnessWingman/WellnessWingman.csproj
+++ b/WellnessWingman/WellnessWingman.csproj
@@ -1,7 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>net10.0-android;net10.0-ios;net10.0-maccatalyst</TargetFrameworks>
+		<TargetFrameworks>net10.0-android</TargetFrameworks>
+		<TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('osx'))">$(TargetFrameworks);net10.0-ios;net10.0-maccatalyst</TargetFrameworks>
 		<TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net10.0-windows10.0.19041.0</TargetFrameworks>
 
 		<!-- Note for MacCatalyst:


### PR DESCRIPTION
Updated `WellnessWingman.csproj` to include `net10.0-ios` and `net10.0-maccatalyst` targets only when building on macOS. This resolves restore errors on Linux/Windows environments while maintaining cross-platform support.

Verified by successfully building the Android target and running unit/UI tests (UI tests skipped as expected in this environment).

---
*PR created automatically by Jules for task [9825708529887826751](https://jules.google.com/task/9825708529887826751) started by @DigitumDei*