### PR TITLE
[codex] Fix local day rollover bounds

### DIFF
--- a/docs/reviews/ask-224-1774936606317/2026-03-31T08-29-47.858Z-review.md
+++ b/docs/reviews/ask-224-1774936606317/2026-03-31T08-29-47.858Z-review.md
@@ -1,0 +1,193 @@
+# Adversarial Review
+
+- Request ID: 227
+- Branch: ask/224-1774936606317
+- Diff Base: origin/master
+- Reviewed Commit: d5b27a30b86b285a0dc13bdf2e7440e30bed41d7
+- Verdict: ready_for_pr
+
+## Executive Summary
+
+This branch fixes a crash on month-end dates (e.g., March 31) caused by manually incrementing dayOfMonth, which produces invalid dates like March 32. The fix replaces the broken manual arithmetic with kotlinx-datetime's `localDate.plus(1, DateTimeUnit.DAY)`, which correctly handles all month-end and year-end rollovers. Both reviewers agree the fix is correct, minimal, and non-blocking. The only meaningful coverage gap is that the new tests use UTC exclusively while production uses the system default timezone.
+
+## Changed Files
+
+- shared/src/commonMain/kotlin/com/wellnesswingman/util/DateTimeConverter.kt
+- shared/src/commonTest/kotlin/com/wellnesswingman/util/DateTimeConverterTest.kt
+
+## Blocking Issues
+
+- None
+
+## Non-Blocking Issues
+
+- Tests only exercise UTC, but production uses system default timezone (shared/src/commonTest/kotlin/com/wellnesswingman/util/DateTimeConverterTest.kt): Both tests pass TimeZone.UTC, making atStartOfDayIn trivial. The production call site in SqlDelightTrackedEntryRepository uses TimeZone.currentSystemDefault(), so a test with a non-UTC timezone (e.g., Pacific/Auckland or America/New_York) would verify the bounds span the correct UTC range for a local day that straddles a UTC date boundary.
+- Duplicated day-boundary logic in DateTimeUtil.kt (shared/src/commonMain/kotlin/com/wellnesswingman/util/DateTimeUtil.kt): DateTimeUtil.getDayBounds computes the same next-day boundary using the same plus(1, DAY) pattern but returns Pair<Long, Long> instead of Pair<Instant, Instant>. Not actionable in this PR since both sites now use correct arithmetic, but worth noting for future consolidation.
+
+## Missing Tests
+
+- Non-UTC timezone test for getUtcBoundsForLocalDay (e.g., Pacific/Auckland or America/New_York) to verify bounds when local day straddles UTC date boundary
+- February 28/29 boundary test (leap year and non-leap year) for completeness, though low risk given library delegation
+
+## Disputed Issues
+
+- None
+
+## Outstanding Concerns
+
+- None
+
+## Analyzer Output
+
+```text
+Intent
+
+Fix a date-handling bug that crashes the app’s front page on month-end dates, specifically when computing the UTC bounds for a local day. The change is intended to replace incorrect manual day increment logic that can produce impossible dates like March 32 with proper date arithmetic, so the home screen can load entries correctly on March 31 and other boundary dates.
+
+Success Criteria
+
+A correct implementation should stop the front-page crash caused by invalid end-of-day date calculation at month boundaries. It should correctly compute the next day for local-day range queries across both month-end and year-end transitions, such as March 31 to April 1 and December 31 to January 1. From the requester’s perspective, the app should open and observe entries normally on those dates without throwing `DateTimeException`.
+```
+
+## Reviewer Outputs
+
+### Codex (codex / gpt-5.4)
+
+```text
+Blocking Issues
+
+None. The code change in [DateTimeConverter.kt](/data/repos/.worktrees/digitumdei/wellnesswingman/224/shared/src/commonMain/kotlin/com/wellnesswingman/util/DateTimeConverter.kt#L69) replaces the invalid manual `dayOfMonth + 1` construction with proper calendar arithmetic, which is the right fix for the stated March 31 / December 31 crash.
+
+Non-Blocking Issues
+
+The added tests in [DateTimeConverterTest.kt](/data/repos/.worktrees/digitumdei/wellnesswingman/224/shared/src/commonTest/kotlin/com/wellnesswingman/util/DateTimeConverterTest.kt#L11) only exercise `TimeZone.UTC`, while production uses `TimeZone.currentSystemDefault()` in [SqlDelightTrackedEntryRepository.kt](/data/repos/.worktrees/digitumdei/wellnesswingman/224/shared/src/commonMain/kotlin/com/wellnesswingman/data/repository/SqlDelightTrackedEntryRepository.kt#L65). That is not evidence of a bug in this patch, but it is weaker coverage than the runtime path actually used by the home screen.
+
+There is also duplicated day-boundary logic in [DateTimeUtil.kt](/data/repos/.worktrees/digitumdei/wellnesswingman/224/shared/src/commonMain/kotlin/com/wellnesswingman/util/DateTimeUtil.kt#L13), which already uses the correct `plus(..., DAY)` approach. This patch fixes the immediate bug, but the duplication still leaves room for future drift.
+
+Missing Tests
+
+A non-UTC timezone case for `getUtcBoundsForLocalDay`, since the repository path depends on local timezone conversion rather than UTC-only behavior.
+
+A February boundary case, especially leap-year rollover (`2024-02-29 -> 2024-03-01`) or non-leap (`2025-02-28 -> 2025-03-01`), to prove this is not just a March/December fix.
+
+A direct repository-level regression test around `getEntriesForDay` / `observeEntriesForDay` would be stronger than a utility-only test, because that is the user-visible crash path.
+
+Strong Concerns
+
+None. This is a small, targeted fix, and the implementation itself looks solid.
+
+Confidence
+
+High on the code fix itself. Moderate on regression coverage, because the new tests are narrower than the production usage path.
+```
+
+### Claude (claude / claude-opus-4-6)
+
+```text
+## Blocking Issues
+
+None.
+
+## Non-Blocking Issues
+
+- The old code `LocalDate(it.year, it.monthNumber, it.dayOfMonth + 1)` is obviously broken on month-end dates — the fix to use `localDate.plus(1, DateTimeUnit.DAY)` is the correct and idiomatic kotlinx-datetime approach. No complaints here.
+
+- The removed intermediate `LocalDate(localDate.year, localDate.monthNumber, localDate.dayOfMonth)` was also pointless — it reconstructed the same `LocalDate` already in hand. Good that it's gone.
+
+## Missing Tests
+
+- **Non-UTC time zone test.** Both tests use `TimeZone.UTC`, which makes `atStartOfDayIn` trivial. A test with a positive or negative offset (e.g., `TimeZone.of("Pacific/Auckland")` at +12/+13, or `America/New_York`) would verify the bounds actually span the correct UTC range for a local day that straddles a UTC date boundary. This is where real-world bugs in day-bound queries surface. Not blocking, but worth adding.
+
+- **February 28/29 (leap year).** The month-end and year-end cases are covered, but Feb 28 in a non-leap year and Feb 29 in a leap year are the other classic boundary. Low risk given `plus(1, DAY)` handles it, but a one-line parameterized case costs nothing.
+
+- **Mid-month "normal" date.** A single happy-path test that a regular date like March 15 produces the expected bounds would round out the suite and serve as a regression baseline. Minor.
+
+## Strong Concerns
+
+None. The bug is real, the fix is minimal and correct, and the new tests directly cover the failure scenarios described in the intent.
+
+## Confidence
+
+**High.** This is a straightforward one-line fix replacing broken manual arithmetic with a well-tested library call. The diff is small, focused, and does exactly what it says. The only gap is test coverage for non-UTC zones, which is a nice-to-have rather than a blocker for this change.
+```
+
+## Critique Outputs
+
+### Round 1: Codex (codex / gpt-5.4)
+
+```text
+Valid Comments
+
+- Claude’s core assessment of the code fix is valid. In [DateTimeConverter.kt](/data/repos/.worktrees/digitumdei/wellnesswingman/224/shared/src/commonMain/kotlin/com/wellnesswingman/util/DateTimeConverter.kt#L63), the old implementation effectively did manual `dayOfMonth + 1`, which is invalid on month-end dates, and replacing it with `localDate.plus(1, DateTimeUnit.DAY)` is the correct `kotlinx-datetime` fix.
+- The note that the removed intermediate `LocalDate(...)` reconstruction was pointless is also valid. It recreated the same date before applying the broken increment, so removing it is a cleanup with no behavior loss.
+- The suggested non-UTC timezone test is well supported. The new tests in [DateTimeConverterTest.kt](/data/repos/.worktrees/digitumdei/wellnesswingman/224/shared/src/commonTest/kotlin/com/wellnesswingman/util/DateTimeConverterTest.kt#L11) only use `TimeZone.UTC`, while the production repository path in [SqlDelightTrackedEntryRepository.kt](/data/repos/.worktrees/digitumdei/wellnesswingman/224/shared/src/commonMain/kotlin/com/wellnesswingman/data/repository/SqlDelightTrackedEntryRepository.kt#L61) uses `TimeZone.currentSystemDefault()`. That makes the test gap real, even if not blocking.
+- The February 28/29 suggestion is reasonable but lower confidence than the non-UTC point. It is supported as extra regression coverage for another month-boundary class, though the library call itself already makes this low risk.
+
+Invalid Or Weak Comments
+
+- The “mid-month normal date” test request is weak. Nothing in the bug or the changed code suggests ordinary dates are a risk area; the regression is specifically about boundary rollover. Calling this out as a missing test overstates the value.
+- “The new tests directly cover the failure scenarios described in the intent” is somewhat overstated. They cover month-end and year-end rollover in UTC, but they do not cover the actual runtime timezone path used by the repository, which is where day-bound query bugs commonly show up.
+
+Missing Context
+
+- Claude does not mention that there is already parallel day-boundary logic in [DateTimeUtil.kt](/data/repos/.worktrees/digitumdei/wellnesswingman/224/shared/src/commonMain/kotlin/com/wellnesswingman/util/DateTimeUtil.kt#L13) using `date.plus(1, DateTimeUnit.DAY)`. That matters because it reinforces that this patch aligns with an existing correct implementation, but also highlights duplication risk.
+- Claude also stops at utility-level coverage. A stronger critique would note that the user-visible path is repository behavior via [SqlDelightTrackedEntryRepository.kt](/data/repos/.worktrees/digitumdei/wellnesswingman/224/shared/src/commonMain/kotlin/com/wellnesswingman/data/repository/SqlDelightTrackedEntryRepository.kt#L61), so a repository-level regression test would better match the actual crash path.
+
+Feedback To Peers
+
+- Keep the non-UTC test point; that is the strongest coverage critique because it is directly tied to production usage.
+- Separate “useful extra coverage” from “evidence-backed risk.” February rollover is a fair nice-to-have; the mid-month suggestion is not well tied to the defect.
+- Be careful with “directly covers the failure scenarios” language when the tests only exercise UTC and the production code uses system local time.
+- When a codebase already contains a parallel correct implementation, call that out. It strengthens the assessment of the fix and can surface duplication/drift risk.
+```
+
+### Round 1: Claude (claude / claude-opus-4-6)
+
+```text
+## Valid Comments
+
+**My review:**
+- Bug analysis is correct: `dayOfMonth + 1` on month-end dates overflows. The fix to `localDate.plus(1, DateTimeUnit.DAY)` is correct.
+- The observation that the removed intermediate `LocalDate` reconstruction was pointless is correct — confirmed by reading the old code in the diff.
+- Non-UTC timezone test suggestion is valid: the production call site (`SqlDelightTrackedEntryRepository.kt:69`) passes `TimeZone.currentSystemDefault()`, so all tests using `TimeZone.UTC` sidestep the timezone offset math in `atStartOfDayIn`.
+- Feb 28/29 suggestion is valid but low-value given `plus(1, DAY)` delegates to the library.
+
+**Codex review:**
+- Correctly identifies the UTC-only test gap and ties it to the actual production call site — stronger justification than my review, which made the same point but without citing the specific caller.
+- Correctly identifies duplicated day-boundary logic in `DateTimeUtil.kt:14-17`. Confirmed: `getDayBounds` does the same `date.plus(1, DateTimeUnit.DAY).atStartOfDayIn(timeZone)` pattern as the fixed `getUtcBoundsForLocalDay`, but returns `Long` millis instead of `Instant`. This is a real observation — the two functions compute the same bounds in different return types.
+
+## Invalid Or Weak Comments
+
+**Codex — "A direct repository-level regression test around `getEntriesForDay` / `observeEntriesForDay`":**
+This is overstated for this PR. The repository methods are thin wrappers that pass millis to a SQL query — the actual logic under test is in `getUtcBoundsForLocalDay`. A repository-level test would require a database fixture and would be testing SqlDelight query execution, not the date arithmetic that was broken. Suggesting it as a "stronger" test conflates integration coverage with unit coverage of the bug. It's a valid desire in general but not a meaningful gap for *this* change.
+
+**Codex — duplication concern framed as a non-blocking issue of this PR:**
+The observation is factually correct, but `DateTimeUtil.getDayBounds` returns `Pair<Long, Long>` while `DateTimeConverter.getUtcBoundsForLocalDay` returns `Pair<Instant, Instant>` — different return types serving different callers. Calling this "duplication that leaves room for future drift" is slightly overstated: the dangerous manual arithmetic that caused the bug has now been removed from both sites, so drift risk is low. It's fair to mention but shouldn't carry weight in evaluating this PR.
+
+## Missing Context
+
+**Neither review mentions the first `LocalDate` reconstruction line specifically enough.** The old code had *two* bugs stacked: (1) `LocalDate(localDate.year, localDate.monthNumber, localDate.dayOfMonth)` needlessly rebuilt the same date, then (2) `LocalDate(it.year, it.monthNumber, it.dayOfMonth + 1)` overflowed on month-end. My review noted the reconstruction was "pointless," and Codex didn't mention it at all. Neither reviewer pointed out that this two-step pattern may have been an attempt to clone-then-mutate that was never refactored — context that could explain how the bug was introduced.
+
+**Neither review verified whether the existing test suite passes on master with the bug present for non-boundary dates** (i.e., confirmed the tests are actually new coverage, not redundant with something already in the repo). Minor, but worth noting since both reviews assert the tests "directly cover" the failure.
+
+## Feedback To Peers
+
+**To Codex:** The duplication callout in `DateTimeUtil.kt` is a good catch that I missed entirely — it adds useful context even if it's not actionable in this PR. However, the repository-level regression test suggestion is out of scope and overstated for a one-line arithmetic fix. The confidence split ("high on fix, moderate on coverage") is well-calibrated overall, but the moderate rating seems driven partly by the repository-test gap, which is an integration concern unrelated to the bug being fixed.
+
+**To myself:** Codex's review is better grounded in the production call path — citing `SqlDelightTrackedEntryRepository.kt:65` as evidence for why non-UTC tests matter is more convincing than my generic "real-world bugs surface here" framing. I should have traced the caller. The `DateTimeUtil` duplication observation is also something I should have caught. My Feb 29 and mid-month suggestions are valid but low-signal filler compared to the one suggestion that actually matters (non-UTC timezone).
+```
+
+## Judge Outputs
+
+### Round 1
+
+- Consensus reached: yes
+- Summary: The reviewers have reached practical consensus. Both agree the code fix is correct, targeted, and non-blocking, and both identify the same main follow-up: adding a non-UTC timezone regression test would strengthen coverage because production uses the system timezone. The remaining disagreements are minor and mostly about review scope and test prioritization, not about whether the PR is acceptable.
+- Reviewer guidance:
+- Codex: Your core judgment aligns with the other review: no blocking defects, fix is correct, and the strongest actionable gap is non-UTC test coverage tied to the production call path. For the next round, de-emphasize repository-level integration testing and duplication risk unless you can show a concrete regression risk from this PR.
+- Claude: Your review is aligned on the important points: no blocking issues and non-UTC coverage is the main worthwhile follow-up. For the next round, keep the focus on evidence-backed risks and trim lower-signal suggestions like mid-month coverage unless they are directly connected to the changed behavior.
+
+```text
+{"consensusReached":true,"consensusSummary":"The reviewers have reached practical consensus. Both agree the code fix is correct, targeted, and non-blocking, and both identify the same main follow-up: adding a non-UTC timezone regression test would strengthen coverage because production uses the system timezone. The remaining disagreements are minor and mostly about review scope and test prioritization, not about whether the PR is acceptable.","reviewerGuidance":[{"reviewer":"Codex","feedback":"Your core judgment aligns with the other review: no blocking defects, fix is correct, and the strongest actionable gap is non-UTC test coverage tied to the production call path. For the next round, de-emphasize repository-level integration testing and duplication risk unless you can show a concrete regression risk from this PR."},{"reviewer":"Claude","feedback":"Your review is aligned on the important points: no blocking issues and non-UTC coverage is the main worthwhile follow-up. For the next round, keep the focus on evidence-backed risks and trim lower-signal suggestions like mid-month coverage unless they are directly connected to the changed behavior."}]}
+```
+

--- a/shared/src/commonMain/kotlin/com/wellnesswingman/util/DateTimeConverter.kt
+++ b/shared/src/commonMain/kotlin/com/wellnesswingman/util/DateTimeConverter.kt
@@ -1,10 +1,12 @@
 package com.wellnesswingman.util
 
 import kotlinx.datetime.Instant
+import kotlinx.datetime.DateTimeUnit
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.LocalDateTime
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.atStartOfDayIn
+import kotlinx.datetime.plus
 import kotlinx.datetime.toInstant
 import kotlinx.datetime.toLocalDateTime
 import kotlin.math.absoluteValue
@@ -69,8 +71,7 @@ object DateTimeConverter {
         timeZone: TimeZone = TimeZone.currentSystemDefault()
     ): Pair<Instant, Instant> {
         val utcStart = localDate.atStartOfDayIn(timeZone)
-        val nextDay = LocalDate(localDate.year, localDate.monthNumber, localDate.dayOfMonth)
-            .let { LocalDate(it.year, it.monthNumber, it.dayOfMonth + 1) }
+        val nextDay = localDate.plus(1, DateTimeUnit.DAY)
         val utcEnd = nextDay.atStartOfDayIn(timeZone)
         return utcStart to utcEnd
     }

--- a/shared/src/commonMain/kotlin/com/wellnesswingman/util/DateTimeConverter.kt
+++ b/shared/src/commonMain/kotlin/com/wellnesswingman/util/DateTimeConverter.kt
@@ -16,6 +16,16 @@ import kotlin.math.absoluteValue
  */
 object DateTimeConverter {
 
+    internal fun getLocalDayBounds(
+        localDate: LocalDate,
+        timeZone: TimeZone = TimeZone.currentSystemDefault()
+    ): Pair<Instant, Instant> {
+        val utcStart = localDate.atStartOfDayIn(timeZone)
+        val nextDay = localDate.plus(1, DateTimeUnit.DAY)
+        val utcEnd = nextDay.atStartOfDayIn(timeZone)
+        return utcStart to utcEnd
+    }
+
     /**
      * Converts the provided UTC instant into its original local representation
      * based on stored timezone metadata.
@@ -70,10 +80,7 @@ object DateTimeConverter {
         localDate: LocalDate,
         timeZone: TimeZone = TimeZone.currentSystemDefault()
     ): Pair<Instant, Instant> {
-        val utcStart = localDate.atStartOfDayIn(timeZone)
-        val nextDay = localDate.plus(1, DateTimeUnit.DAY)
-        val utcEnd = nextDay.atStartOfDayIn(timeZone)
-        return utcStart to utcEnd
+        return getLocalDayBounds(localDate, timeZone)
     }
 
     /**

--- a/shared/src/commonMain/kotlin/com/wellnesswingman/util/DateTimeUtil.kt
+++ b/shared/src/commonMain/kotlin/com/wellnesswingman/util/DateTimeUtil.kt
@@ -12,8 +12,7 @@ object DateTimeUtil {
      * Returns (startOfDay, endOfDay) where endOfDay is exclusive.
      */
     fun getDayBounds(date: LocalDate, timeZone: TimeZone = TimeZone.currentSystemDefault()): Pair<Long, Long> {
-        val startOfDay = date.atStartOfDayIn(timeZone)
-        val endOfDay = date.plus(1, DateTimeUnit.DAY).atStartOfDayIn(timeZone)
+        val (startOfDay, endOfDay) = DateTimeConverter.getLocalDayBounds(date, timeZone)
         return Pair(startOfDay.toEpochMilliseconds(), endOfDay.toEpochMilliseconds())
     }
 

--- a/shared/src/commonTest/kotlin/com/wellnesswingman/util/DateTimeConverterTest.kt
+++ b/shared/src/commonTest/kotlin/com/wellnesswingman/util/DateTimeConverterTest.kt
@@ -25,4 +25,14 @@ class DateTimeConverterTest {
         assertEquals(LocalDate(2026, 12, 31), start.toLocalDateTime(TimeZone.UTC).date)
         assertEquals(LocalDate(2027, 1, 1), end.toLocalDateTime(TimeZone.UTC).date)
     }
+
+    @Test
+    fun `getUtcBoundsForLocalDay handles non-UTC timezone correctly`() {
+        val date = LocalDate(2026, 3, 31)
+        val timeZone = TimeZone.of("America/New_York")
+        val (start, end) = DateTimeConverter.getUtcBoundsForLocalDay(date, timeZone)
+
+        assertEquals(date, start.toLocalDateTime(timeZone).date)
+        assertEquals(LocalDate(2026, 4, 1), end.toLocalDateTime(timeZone).date)
+    }
 }

--- a/shared/src/commonTest/kotlin/com/wellnesswingman/util/DateTimeConverterTest.kt
+++ b/shared/src/commonTest/kotlin/com/wellnesswingman/util/DateTimeConverterTest.kt
@@ -1,5 +1,6 @@
 package com.wellnesswingman.util
 
+import kotlinx.datetime.Instant
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toLocalDateTime
@@ -34,5 +35,18 @@ class DateTimeConverterTest {
 
         assertEquals(date, start.toLocalDateTime(timeZone).date)
         assertEquals(LocalDate(2026, 4, 1), end.toLocalDateTime(timeZone).date)
+    }
+
+    @Test
+    fun `getUtcBoundsForLocalDay returns correct UTC instants for non-UTC timezone`() {
+        // America/New_York is UTC-4 on 2026-03-31 (EDT).
+        // Local midnight maps to 04:00 UTC, so the day bounds in UTC are
+        // [2026-03-31T04:00:00Z, 2026-04-01T04:00:00Z).
+        val date = LocalDate(2026, 3, 31)
+        val timeZone = TimeZone.of("America/New_York")
+        val (start, end) = DateTimeConverter.getUtcBoundsForLocalDay(date, timeZone)
+
+        assertEquals(Instant.parse("2026-03-31T04:00:00Z"), start)
+        assertEquals(Instant.parse("2026-04-01T04:00:00Z"), end)
     }
 }

--- a/shared/src/commonTest/kotlin/com/wellnesswingman/util/DateTimeConverterTest.kt
+++ b/shared/src/commonTest/kotlin/com/wellnesswingman/util/DateTimeConverterTest.kt
@@ -1,0 +1,28 @@
+package com.wellnesswingman.util
+
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.toLocalDateTime
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class DateTimeConverterTest {
+
+    @Test
+    fun `getUtcBoundsForLocalDay rolls over month end correctly`() {
+        val date = LocalDate(2026, 3, 31)
+        val (start, end) = DateTimeConverter.getUtcBoundsForLocalDay(date, TimeZone.UTC)
+
+        assertEquals(LocalDate(2026, 3, 31), start.toLocalDateTime(TimeZone.UTC).date)
+        assertEquals(LocalDate(2026, 4, 1), end.toLocalDateTime(TimeZone.UTC).date)
+    }
+
+    @Test
+    fun `getUtcBoundsForLocalDay rolls over year end correctly`() {
+        val date = LocalDate(2026, 12, 31)
+        val (start, end) = DateTimeConverter.getUtcBoundsForLocalDay(date, TimeZone.UTC)
+
+        assertEquals(LocalDate(2026, 12, 31), start.toLocalDateTime(TimeZone.UTC).date)
+        assertEquals(LocalDate(2027, 1, 1), end.toLocalDateTime(TimeZone.UTC).date)
+    }
+}


### PR DESCRIPTION
## Summary
- fix the local-day UTC bound calculation to use calendar-aware date arithmetic
- add regression tests for month-end and year-end rollover cases
- include the review artifact for this branch under `docs/reviews/ask-224-1774936606317/`

## Root Cause
The home-screen query path built the next day by manually incrementing `dayOfMonth`, which produced invalid dates like March 32 on month-end boundaries.

## Impact
The front page should no longer crash on dates such as March 31, 2026 when observing entries for the current day.

## Validation
- Added focused regression tests in `DateTimeConverterTest`
- Could not run Gradle tests in this environment because Java was unavailable (`JAVA_HOME` unset / `java` missing)
