### PR TITLE
Refresh docs and optimize Gradle startup

### DIFF
--- a/BUILD_FIXES_NEEDED.md
+++ b/BUILD_FIXES_NEEDED.md
@@ -1,32 +1,21 @@
 # Build Fixes Applied
 
-All compilation errors have been resolved. The Android app builds and runs successfully.
+This document is historical context, not a live build-status report.
 
-## Fixes Applied
+It summarizes notable build/runtime fixes that were applied during earlier stabilization work:
 
-### Dependencies
-- ✅ Koin: Changed from `koin-compose` to `koin-androidx-compose`
-- ✅ Coil: Downgraded from 3.0.0 to 2.5.0 and removed network-ktor module
+- Koin Compose dependency alignment
+- Coil dependency rollback from the unsupported newer line
+- Gemini authentication and response-handling fixes
+- process-death recovery for pending captures
+- Android theme and manifest/build cleanup
+- zip-slip and path-normalization hardening in migration/export paths
+- Gradle configuration cleanup, including removal of a hardcoded Java home
 
-### Compilation Errors (all resolved)
-- ✅ Repository API: `getEntriesBetween()` → `getEntriesForDay()` in calendar ViewModels
-- ✅ Clock API: `Clock.System.Today()` → `Clock.System.now().toLocalDateTime(TimeZone.currentSystemDefault()).date`
-- ✅ CalendarMonth type: Replaced with `kotlinx.datetime.LocalDate`
-- ✅ TrackedEntry timezone handling: Proper `Instant` → `LocalDate` conversion via `DateTimeUtil`
-- ✅ Experimental Material3 APIs: Added `@OptIn` annotations
+For the current runnable and verification workflow, use:
 
-### Runtime Fixes
-- ✅ Gemini API auth: Changed from query param to `x-goog-api-key` header
-- ✅ Gemini API serialization: Replaced sealed class `GeminiPart` with flat data class (avoids `type` discriminator)
-- ✅ Gemini API error handling: Added HTTP status checking and error body logging
-- ✅ Gemini API response sanitization: Strip `` ```json `` code fences from LLM responses
-- ✅ Camera process death recovery: File-based `PendingCaptureStore` persists capture state across process death
-- ✅ Android theme: Using `Theme.AppCompat.DayNight.NoActionBar` (defined in `res/values/themes.xml`)
+- [README.md](README.md)
+- [RUNNING_THE_APP.md](RUNNING_THE_APP.md)
+- [TESTING.md](TESTING.md)
 
-### Security Fixes
-- ✅ Zip-slip vulnerability: Path traversal check in `ZipUtil` (both Android and Desktop)
-- ✅ Path normalization: `DataMigrationService` normalizes backslashes before path comparison
-
-### Build Config
-- ✅ Removed hardcoded `org.gradle.java.home` from `gradle.properties`
-- ✅ `gradlew` marked as executable (`git update-index --chmod=+x`)
+In this workspace, Gradle commands could not be re-run during the documentation refresh because `java` is not installed and `JAVA_HOME` is unset.

--- a/BUILD_FIXES_NEEDED.md
+++ b/BUILD_FIXES_NEEDED.md
@@ -17,5 +17,3 @@ For the current runnable and verification workflow, use:
 - [README.md](README.md)
 - [RUNNING_THE_APP.md](RUNNING_THE_APP.md)
 - [TESTING.md](TESTING.md)
-
-In this workspace, Gradle commands could not be re-run during the documentation refresh because `java` is not installed and `JAVA_HOME` is unset.

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -1,338 +1,45 @@
-# WellnessWingman Kotlin Multiplatform Migration - Progress Tracker
+# WellnessWingman Progress
 
-**Last Updated:** 2026-01-30
-**Overall Progress:** 20 of 24 tasks (83.3%)
-**Status:** Production Ready for Android
+**Last Updated:** 2026-04-01  
+**Status:** Active Android-first Kotlin Multiplatform application
 
----
+## Snapshot
 
-## ✅ Phase 1: Foundation (5/5 tasks - 100%)
+The repository is no longer best described as a migration-in-progress checklist. The active codebase now includes:
 
-### Task #1: Set up KMP project structure ✅
-**Status:** Completed
-**Files:** Build configuration, Gradle setup, module structure
-- [x] Root build.gradle.kts with version catalog
-- [x] settings.gradle.kts with module configuration
-- [x] gradle/libs.versions.toml with all dependencies
-- [x] Module structure: shared, composeApp, androidApp
-- [x] Platform-specific source sets (Android, iOS, Desktop)
+- shared SQLDelight-backed persistence for tracked entries, analyses, summaries, nutrition profiles, Polar sync state, and weight history
+- shared LLM integration for OpenAI and Gemini
+- shared daily and weekly summary generation with tool-calling support
+- Android share-intent capture, OAuth deep-link handling, and background work scheduling
+- Polar OAuth, API client integration, persisted sync checkpoints, refresh orchestration, and insight generation
+- nutrition-label scanning plus saved nutritional profile management
+- data export/import and diagnostics sharing
 
-### Task #2: Create data models ✅
-**Status:** Completed
-**Files:** 10+ data model files in `shared/src/commonMain/kotlin/com/wellnesswingman/data/model/`
-- [x] EntryType.kt
-- [x] ProcessingStatus.kt
-- [x] TrackedEntry.kt
-- [x] EntryAnalysis.kt
-- [x] DailySummary.kt
-- [x] TrackedEntryCard.kt
-- [x] MealAnalysisResult.kt
-- [x] ExerciseAnalysisResult.kt
-- [x] SleepAnalysisResult.kt
-- [x] Supporting models (NutritionEstimate, HealthInsights, etc.)
+## March 2026 Completed PRs
 
-### Task #3: Set up SQLDelight schemas ✅
-**Status:** Completed
-**Files:** SQL schemas and database drivers
-- [x] TrackedEntry.sq with 15+ queries
-- [x] EntryAnalysis.sq with 10+ queries
-- [x] DailySummary.sq with 12+ queries
-- [x] DriverFactory.kt (expect declaration)
-- [x] DriverFactory.android.kt
-- [x] DriverFactory.ios.kt
-- [x] DriverFactory.desktop.kt
+Major product and architecture work merged during March 2026:
 
-### Task #4: Implement repository layer ✅
-**Status:** Completed
-**Files:** Repository interfaces and implementations
-- [x] TrackedEntryRepository.kt
-- [x] SqlDelightTrackedEntryRepository.kt
-- [x] EntryAnalysisRepository.kt
-- [x] SqlDelightEntryAnalysisRepository.kt
-- [x] DailySummaryRepository.kt
-- [x] SqlDelightDailySummaryRepository.kt
-- [x] AppSettingsRepository.kt
-- [x] SettingsAppSettingsRepository.kt
+- `#127` nutritional profile workflow
+- `#125` tool registry wiring for daily and weekly summaries
+- `#123` shared LLM tool-calling support and issue 100 work
+- `#121` Polar insight bridge and day-detail follow-ups
+- `#120` Polar sync persistence and refresh orchestration
+- `#119` shared Polar API client and DTO mapping
+- `#118` Polar OAuth integration milestone 1
+- `#102` sectioned settings navigation
+- `#93` image retention service and Android background worker
 
-### Task #5: Port business logic services ✅
-**Status:** Completed
-**Files:** Pure business logic
-- [x] DailyTotalsCalculator.kt
-- [x] DateTimeUtil.kt
+Supporting maintenance work during the same month included documentation cleanup, app icon updates, workflow updates, and multiple dependency security bumps.
 
----
+## Active Focus Areas
 
-## ✅ Phase 2: Core Business Logic (5/5 tasks - 100%)
+- keep Android documentation and operational guides aligned with the shipped code
+- continue growing shared and Compose test coverage toward the repository’s long-term targets
+- re-enable or modernize the iOS Gradle target setup when the Kotlin/Gradle compatibility path is ready
+- expand manual verification around OAuth, WorkManager, and media flows that are not fully covered by automated tests
 
-### Task #6: Implement LLM client interfaces ✅
-**Status:** Completed
-**Files:** LLM integration layer
-- [x] LlmClient.kt (interface)
-- [x] OpenAiLlmClient.kt (using openai-kotlin)
-- [x] GeminiLlmClient.kt (using Ktor HTTP)
-- [x] LlmClientFactory.kt
-- [x] Request/response models
+## Open Gaps
 
-### Task #7: Implement analysis orchestrator ✅
-**Status:** Completed
-**Files:** Entry processing pipeline
-- [x] AnalysisOrchestrator.kt
-- [x] AnalysisInvocationResult sealed class
-- [x] Prompt building logic
-- [x] Status management
-- [x] Error handling
-
-### Task #8: Implement daily summary service ✅
-**Status:** Completed
-**Files:** Summary generation
-- [x] DailySummaryService.kt
-- [x] Summary generation with LLM
-- [x] Nutrition totals aggregation
-- [x] Regeneration support
-
-### Task #9: Implement platform services (expect/actual) ✅
-**Status:** Completed
-**Files:** Platform-specific implementations
-- [x] FileSystem.kt (expect)
-- [x] FileSystem.android.kt
-- [x] FileSystem.ios.kt
-- [x] FileSystem.desktop.kt
-- [x] CameraCaptureService.kt (expect)
-- [x] CameraCaptureService.android.kt
-- [x] CameraCaptureService.ios.kt
-- [x] CameraCaptureService.desktop.kt
-- [x] PhotoResizer.kt (expect)
-- [x] PhotoResizer.android.kt
-- [x] PhotoResizer.ios.kt
-- [x] PhotoResizer.desktop.kt
-
-### Task #10: Set up dependency injection with Koin ✅
-**Status:** Completed
-**Files:** Complete DI configuration
-- [x] DataModule.kt
-- [x] DomainModule.kt
-- [x] SharedModules.kt
-- [x] PlatformModule.android.kt
-- [x] PlatformModule.ios.kt
-- [x] PlatformModule.desktop.kt
-- [x] ViewModelModule.kt
-
----
-
-## ✅ Phase 3: UI Layer (7/7 tasks - 100%)
-
-### Task #11: Create Compose UI theme and design system ✅
-**Status:** Completed
-**Files:** Material3 theming
-- [x] Color.kt (light & dark color schemes)
-- [x] Typography.kt
-- [x] Theme.kt
-- [x] LoadingIndicator.kt
-- [x] ErrorMessage.kt
-- [x] EmptyState.kt
-
-### Task #12: Implement navigation with Voyager ✅
-**Status:** Completed
-**Files:** Navigation setup
-- [x] App.kt (root composable with Navigator)
-- [x] Screen definitions
-- [x] Slide transitions
-
-### Task #13: Create MainScreen with entry list ✅
-**Status:** Completed
-**Files:** Main entry list screen
-- [x] MainScreen.kt
-- [x] MainViewModel.kt
-- [x] EntryCard composable
-- [x] StatusChip composable
-- [x] Pull-to-refresh support
-- [x] Navigation to detail screens
-
-### Task #14: Create SettingsScreen ✅
-**Status:** Completed
-**Files:** Settings and configuration
-- [x] SettingsScreen.kt
-- [x] SettingsViewModel.kt
-- [x] LLM provider selection
-- [x] API key input (password-masked)
-- [x] Save/load functionality
-- [x] Snackbar feedback
-
-### Task #15: Create detail screens (Meal, Exercise, Sleep) ✅
-**Status:** Completed
-**Files:** Entry detail views
-- [x] EntryDetailScreen.kt
-- [x] EntryDetailViewModel.kt
-- [x] MealAnalysisCard composable
-- [x] ExerciseAnalysisCard composable
-- [x] SleepAnalysisCard composable
-- [x] Delete functionality with confirmation
-- [x] Navigation integration
-
-### Task #16: Create PhotoReviewScreen ✅
-**Status:** Completed
-**Files:** Photo capture and review UI
-- [x] PhotoReviewViewModel.kt
-- [x] PhotoReviewScreen.kt
-- [x] Camera capture integration
-- [x] Gallery picker integration
-- [x] Photo review with entry type selection
-- [x] Notes input
-- [x] Confirm/retry functionality
-- [x] Navigation to EntryDetailScreen after creation
-
-### Task #17: Create calendar views (Week, Month, Year, Day) ✅
-**Status:** Completed
-**Files:** Timeline views for entries
-- [x] CalendarViewModel.kt
-- [x] WeekViewModel.kt
-- [x] YearViewModel.kt
-- [x] DayDetailViewModel.kt
-- [x] MonthViewScreen.kt with calendar grid
-- [x] WeekViewScreen.kt with daily sections
-- [x] YearViewScreen.kt with month summary cards
-- [x] DayDetailScreen.kt with entry list
-- [x] Navigation integration from MainScreen
-- [x] Date navigation (previous/next/today)
-
-### Task #18: Create DailySummaryScreen ✅
-**Status:** Completed
-**Files:** Daily summary display
-- [x] DailySummaryScreen.kt
-- [x] DailySummaryViewModel.kt
-- [x] Summary content display
-- [x] Generate/regenerate functionality
-- [x] Loading and error states
-- [x] Empty states (no summary, no entries)
-
----
-
-## ✅ Phase 4: Android Application (1/1 task - 100%)
-
-### Task #19: Set up Android app module ✅
-**Status:** Completed
-**Files:** Android application entry point
-- [x] MainActivity.kt
-- [x] WellnessWingmanApp.kt (Application class)
-- [x] AndroidManifest.xml
-- [x] Build configuration
-- [x] Koin initialization
-- [x] Napier logging setup
-- [x] ProGuard rules
-- [x] Resource files (strings, colors, file_paths)
-
----
-
-## ⏳ Phase 5: Testing & Polish (0/5 tasks - 0%)
-
-### Task #20: Port unit tests to kotlin.test ✅
-**Status:** Completed
-**Files:** Comprehensive unit test suite created
-- [x] DailyTotalsCalculatorTest.kt - Business logic tests
-- [x] DateTimeUtilTest.kt - Utility function tests
-- [x] TrackedEntryTest.kt - Data model tests
-- [x] MealAnalysisResultTest.kt - JSON serialization tests
-- [x] SqlDelightTrackedEntryRepositoryTest.kt - Repository tests with in-memory DB
-- [x] Test dependencies configured (kotlin-test, coroutines-test, mockk, turbine)
-- [x] SQLDelight JDBC driver for in-memory testing
-**Note:** Tests require Java 17/21 to run (see TESTING.md)
-
-### Task #21: Set up code coverage with Kover ⏳
-**Status:** Pending (Optional)
-**Description:** Configure test coverage reporting
-**Requirements:**
-- [ ] Add Kover plugin configuration
-- [ ] Configure coverage filters
-- [ ] Set minimum coverage thresholds (70%)
-- [ ] Generate HTML/XML reports
-
-### Task #22: Create Maestro E2E test flows ⏳
-**Status:** Pending (Optional)
-**Description:** End-to-end testing
-**Requirements:**
-- [ ] smoke_test.yaml
-- [ ] create_entry.yaml
-- [ ] navigation.yaml
-- [ ] settings.yaml
-
-### Task #23: Set up iOS app module (basic) ⏳
-**Status:** Pending (Optional)
-**Description:** Basic iOS application structure
-**Requirements:**
-- [ ] Xcode project setup
-- [ ] ContentView.swift calling Compose
-- [ ] Info.plist configuration
-- [ ] Complete iOS platform implementations
-- [ ] Camera/Photos permissions
-
-### Task #24: Create documentation and README ✅
-**Status:** Completed
-**Files:** Project documentation
-- [x] README.md with comprehensive overview
-- [x] Build instructions
-- [x] Architecture documentation
-- [x] Migration status
-- [x] PROGRESS.md (this file)
-
----
-
-## 📊 Summary Statistics
-
-| Phase | Completed | Total | Percentage |
-|-------|-----------|-------|------------|
-| Phase 1: Foundation | 5 | 5 | 100% |
-| Phase 2: Core Logic | 5 | 5 | 100% |
-| Phase 3: UI Layer | 7 | 7 | 100% |
-| Phase 4: Android App | 1 | 1 | 100% |
-| Phase 5: Testing | 1 | 5 | 20% |
-| **TOTAL** | **20** | **24** | **83.3%** |
-
-## 🎯 Key Milestones Achieved
-
-- ✅ **Complete data and business logic layer**
-- ✅ **Full dependency injection with Koin**
-- ✅ **Cross-platform database with SQLDelight**
-- ✅ **Dual LLM provider support (OpenAI + Gemini)**
-- ✅ **Production-ready Android application**
-- ✅ **Kotlin 2.2.0 with latest dependencies**
-- ✅ **Gradle wrapper generated (9.3.0)**
-- ✅ **Comprehensive unit test suite**
-- ✅ **Material3 UI with complete screen set (9 screens)**
-- ✅ **Photo capture and review flow**
-- ✅ **Calendar views (Week/Month/Year/Day)**
-- ✅ **Type-safe navigation with Voyager**
-
-## 🚀 Production Readiness
-
-### Ready for Production ✅
-- Android app with complete feature set
-- Database persistence
-- LLM integration (OpenAI + Gemini)
-- Settings management
-- Entry tracking and analysis
-- Daily summaries
-- Photo capture and review
-- Calendar timeline views (Week/Month/Year/Day)
-
-### Optional Enhancements ⏳
-- Comprehensive testing (Tasks #20-22)
-- iOS support (Task #23)
-
-## 📁 File Statistics
-
-- **Total Files Created:** 96+
-- **Lines of Code:** ~12,000+
-- **Shared Module:** 65+ files
-- **ComposeApp Module:** 42+ files (9 complete screens)
-- **AndroidApp Module:** 10+ files
-
-## 🔗 Related Documentation
-
-- [README.md](README.md) - Project overview and setup
-- [MIGRATION_ANALYSIS.md](MIGRATION_ANALYSIS.md) - Detailed migration planning
-- [Build Instructions](README.md#building-the-project) - How to build and run
-
----
-
-**Note:** Tasks marked as "Pending (Optional)" are not required for core functionality.
-The application is production-ready for Android with all critical features implemented.
+- Gradle iOS targets remain disabled in build scripts even though `iosApp/` is still present
+- the current Kover-enforced minimum in Gradle is still a low baseline compared with the repository coverage target
+- Android-specific runtime paths such as camera capture, notifications, and background work still need manual validation on real devices/emulators as changes land

--- a/README.md
+++ b/README.md
@@ -79,7 +79,6 @@ See [RUNNING_THE_APP.md](RUNNING_THE_APP.md) for Android setup and [TESTING.md](
 - The main shared test suite runs via `:shared:desktopTest`.
 - Compose/common presentation tests live under `composeApp/src/commonTest/`.
 - Kover is enabled in `shared/` and currently verifies a 25% minimum baseline while coverage continues to grow.
-- In this workspace, Gradle tasks cannot run until Java is installed and `JAVA_HOME` is set.
 
 ## Architecture
 

--- a/README.md
+++ b/README.md
@@ -1,177 +1,102 @@
-# WellnessWingman - Kotlin Multiplatform
+# WellnessWingman
 
-This is the Kotlin Multiplatform (KMP) migration of the WellnessWingman health tracking application.
+WellnessWingman is a Kotlin Multiplatform health-tracking app with a shared data/domain layer, a shared Compose UI module, and an Android app entry point. The active repository is the Kotlin codebase; older MAUI migration material remains only as historical reference.
 
-## Project Structure
+## Current State
 
+- Android is the primary runnable target in this repository.
+- Shared modules cover data storage, LLM-driven analysis, daily and weekly summaries, Polar integration, nutrition profile workflows, and export/import support.
+- iOS source remains in the repo, but Gradle iOS targets are currently disabled while the project stays aligned with the current Kotlin and Gradle toolchain.
+- Polar OAuth uses the included `polar-oauth-broker/` backend so the mobile client never stores the Polar client secret.
+
+## Recent Changes
+
+Merged during March 2026:
+
+- Polar OAuth, API client wiring, sync persistence, refresh orchestration, and insight bridging landed in PRs `#118`, `#119`, `#120`, and `#121`.
+- Shared LLM tool calling and summary-service tool registry wiring landed in PRs `#123` and `#125`.
+- Nutrition profile persistence, editing, and label-scanning workflow landed in PR `#127`.
+- Settings were reorganized into sectioned navigation in PR `#102`.
+- Image retention/downsizing background work landed in PR `#93`.
+- Several npm dependency security updates also merged during the month.
+
+## Module Layout
+
+- `shared/`: domain models, repositories, SQLDelight schema/migrations, platform abstractions, LLM clients, Polar sync logic, summaries, exports, and media services.
+- `composeApp/`: shared Compose UI, Voyager navigation, screen models, and presentation logic.
+- `androidApp/`: Android application, manifest, startup wiring, WorkManager jobs, share intents, and OAuth deep-link handling.
+- `iosApp/`: Xcode host app for the shared Kotlin framework.
+- `polar-oauth-broker/`: Python broker plus Terraform for Polar OAuth token exchange and refresh.
+- `docs/`: architecture notes and feature-specific docs.
+
+## Major Features
+
+- Capture meal, exercise, and sleep entries from the app or Android image-share intents.
+- Analyze entries with OpenAI or Gemini-backed LLM flows.
+- Generate daily and weekly summaries with tool-calling support for profile, history, and recent-entry context.
+- Connect a Polar account, persist sync checkpoints, refresh data in the foreground, and schedule Android background sync.
+- Manage nutrition profiles by scanning packaged-food labels and saving exact macro profiles.
+- Track weight history and use it in summaries and profile flows.
+- Export and import app data from settings.
+- Share diagnostics logs from the app.
+- Downsize older completed-entry images with the Android retention worker.
+
+## Build Requirements
+
+- JDK 17 or newer available through `JAVA_HOME` or `PATH`
+- Android SDK installed locally
+- `local.properties` configured for your Android SDK
+
+Optional local configuration:
+
+```properties
+sdk.dir=/path/to/Android/Sdk
+polar.client.id=your-polar-client-id
+polar.broker.base.url=https://your-cloud-function-url
 ```
-kotlin/
-├── shared/                      # Shared KMP module
-│   └── src/
-│       ├── commonMain/kotlin/   # Shared business logic
-│       │   ├── com/wellnesswingman/
-│       │   │   ├── data/        # Data layer
-│       │   │   │   ├── db/      # Database drivers
-│       │   │   │   ├── model/   # Data models
-│       │   │   │   └── repository/  # Repositories
-│       │   │   ├── domain/      # Business logic
-│       │   │   │   ├── analysis/  # Analysis services
-│       │   │   │   └── llm/     # LLM clients
-│       │   │   └── util/        # Utilities
-│       │   └── sqldelight/      # SQL schemas
-│       ├── androidMain/kotlin/  # Android implementations
-│       ├── iosMain/kotlin/      # iOS implementations
-│       └── desktopMain/kotlin/  # Desktop implementations
-├── composeApp/                  # Compose Multiplatform UI
-├── androidApp/                  # Android application
-├── iosApp/                      # iOS application (Xcode)
-└── maestro/                     # E2E tests
-```
 
-## Tech Stack
-
-- **Language:** Kotlin 2.2.10
-- **UI Framework:** Compose Multiplatform 1.7.0
-- **Database:** SQLDelight 2.0.2
-- **Dependency Injection:** Koin 3.5.3
-- **HTTP Client:** Ktor 2.3.12
-- **LLM Integration:** openai-kotlin 3.7.2
-- **Navigation:** Voyager 1.1.0-beta02
-- **Image Loading:** Coil 2.5.0
-- **Logging:** Napier 2.7.1
-- **Testing:** kotlin.test, MockK, Turbine
-- **Code Coverage:** Kover 0.8.3
-
-## Current Implementation Status
-
-### ✅ Completed (21 of 24 tasks - 87.5%)
-
-#### **Phase 1: Foundation (100% Complete)**
-1. **Project Structure** - Full KMP setup with Gradle and modules
-2. **Data Models** - All domain models (10+ files)
-3. **SQLDelight Schemas** - Database with cross-platform drivers
-4. **Repository Layer** - Complete data access layer
-
-#### **Phase 2: Core Business Logic (100% Complete)**
-5. **Business Logic Services** - Calculators and utilities
-6. **LLM Client Interfaces** - OpenAI and Gemini clients
-7. **Analysis Orchestrator** - Entry processing pipeline
-8. **Daily Summary Service** - Summary generation with LLM
-9. **Platform Services** - FileSystem, Camera, PhotoResizer (expect/actual)
-10. **Dependency Injection** - Complete Koin setup
-
-#### **Phase 3: UI Layer (100% Complete)**
-11. **Compose UI Theme** - Material3 theme with light/dark modes
-12. **Navigation** - Voyager setup with screen transitions
-13. **MainScreen** - Entry list with pull-to-refresh
-14. **SettingsScreen** - API key configuration and provider selection
-15. **Detail Screens** - Unified entry detail view for Meal/Exercise/Sleep
-16. **PhotoReviewScreen** - Photo capture and review UI
-17. **Calendar Views** - Week, Month, Year, Day timeline views
-18. **DailySummaryScreen** - Daily summary generation and display
-19. **Android App Module** - MainActivity and Application class with full DI
-
-#### **Phase 4: Testing & Quality (67% Complete)**
-20. **Unit Tests** - 39 tests passing with kotlin.test
-21. **Code Coverage** - Kover setup with 25.5% baseline coverage
-24. **Documentation** - README, RUNNING_THE_APP.md, BUILD_FIXES_NEEDED.md
-
-### 🚧 Pending (3 of 24 tasks - Optional)
-
-22. **E2E Tests** - Maestro flows
-23. **iOS App Module** - Blocked by Gradle 9.3 compatibility issues with iOS targets
-    - iOS platform implementations exist in `shared/src/iosMain`
-    - Targets disabled temporarily pending Kotlin/Gradle compatibility updates
-
-## Building the Project
-
-### Prerequisites
-
-- **JDK 17** (configured in `gradle.properties`)
-- **Gradle 9.3.0** (included via wrapper)
-- **Android Studio** (recommended for Android development)
-- **Xcode** (for iOS development, macOS only - currently disabled)
-
-### Quick Start
-
-See [RUNNING_THE_APP.md](RUNNING_THE_APP.md) for comprehensive guide on:
-- Building from command line
-- Running in emulator/device
-- Debugging in Android Studio
-- Viewing logs and troubleshooting
-
-### Build Commands
+## Common Commands
 
 ```bash
-# Build Android debug APK
-./gradlew :androidApp:assembleDebug
+# Build the Android debug app
+./gradlew assembleDebug
 
-# Run all unit tests (39 tests)
-./gradlew :shared:test
+# Run the shared desktop/unit test suite
+./gradlew :shared:desktopTest
 
-# Generate code coverage report (HTML)
-./gradlew :shared:test :shared:koverHtmlReport
+# Generate Kover reports
+./gradlew :shared:koverXmlReport
+./gradlew :shared:koverHtmlReport
 
-# View coverage report
-# Opens: shared/build/reports/kover/html/index.html
-
-# Verify coverage meets threshold
-./gradlew :shared:koverVerify
+# Run the broader verification pass
+./gradlew check
 ```
 
-## Database
+See [RUNNING_THE_APP.md](RUNNING_THE_APP.md) for Android setup and [TESTING.md](TESTING.md) for the current verification workflow.
 
-The app uses SQLDelight for type-safe SQL queries across all platforms.
+## Testing Notes
 
-### Database Location
-
-- **Android:** `/data/data/com.wellnesswingman/databases/wellnesswingman.db`
-- **iOS:** App documents directory
-- **Desktop:** `~/.wellnesswingman/wellnesswingman.db`
-
-## LLM Integration
-
-The app supports two LLM providers:
-
-1. **OpenAI** (gpt-4o-mini)
-   - Image analysis
-   - Audio transcription (Whisper)
-   - Text completion
-
-2. **Google Gemini** (gemini-1.5-flash)
-   - Image analysis
-   - Text completion
-
-API keys are stored securely using platform-specific secure storage:
-- Android: EncryptedSharedPreferences
-- iOS: Keychain
-- Desktop: OS-specific credential storage
+- The main shared test suite runs via `:shared:desktopTest`.
+- Compose/common presentation tests live under `composeApp/src/commonTest/`.
+- Kover is enabled in `shared/` and currently verifies a 25% minimum baseline while coverage continues to grow.
+- In this workspace, Gradle tasks cannot run until Java is installed and `JAVA_HOME` is set.
 
 ## Architecture
 
-The project follows clean architecture principles:
+The project uses a layered KMP design:
 
-- **Data Layer:** Repositories, database access, network clients
-- **Domain Layer:** Business logic, use cases, LLM orchestration
-- **UI Layer:** Compose Multiplatform screens and components
+- data: SQLDelight-backed repositories, settings, OAuth, and API clients
+- domain: analysis orchestration, summaries, tool registry, Polar sync, exports, media retention
+- ui: Compose screens and screen models
+- platform: Android-specific app startup, WorkManager, secure storage, file handling, camera, audio, and sharing
 
-## Migration History
+See [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) and [docs/POLAR.md](docs/POLAR.md) for more detail.
 
-This repository previously contained a .NET MAUI implementation. That code is no longer shipped or supported here; this section is historical context only. Key migration differences were:
+## Historical Docs
 
-- C# → Kotlin
-- XAML → Compose
-- Entity Framework Core → SQLDelight
-- .NET DI → Koin
-- Platform-specific code using expect/actual pattern
-
-See `MIGRATION_ANALYSIS.md` for the archived migration analysis.
-
-## Contributing
-
-This is currently a work in progress. The core data and business logic layers are complete,
-with UI and platform-specific implementations still in progress.
+- [MIGRATION_ANALYSIS.md](MIGRATION_ANALYSIS.md): archived MAUI-to-Kotlin migration analysis
+- [PROGRESS.md](PROGRESS.md): current implementation snapshot and recent milestone log
 
 ## License
 
-MIT License — see [LICENSE.txt](LICENSE.txt) for details.
+MIT. See [LICENSE.txt](LICENSE.txt).

--- a/RUNNING_THE_APP.md
+++ b/RUNNING_THE_APP.md
@@ -1,299 +1,131 @@
-# Running the WellnessWingman Android App
+# Running WellnessWingman
 
-This guide will help you build, run, and debug the WellnessWingman Android app on an emulator or device.
+This repository currently ships an Android-first Kotlin Multiplatform setup. The fastest path is to build and run the Android app from the repo root.
 
 ## Prerequisites
 
-1. **Java 17** - Already installed at `C:\Program Files\Eclipse Adoptium\jdk-17.0.17.10-hotspot`
-2. **Android SDK** - Install via Android Studio or command line tools
-3. **Android Emulator** - At least one emulator device configured
+- JDK 17 or newer installed and available via `JAVA_HOME` or `PATH`
+- Android SDK installed
+- `local.properties` present with at least `sdk.dir=/path/to/Android/Sdk`
 
-## Project Structure
+Optional for Polar testing:
 
-```
-kotlin/
-├── androidApp/          # Android application module (entry point)
-│   ├── build.gradle.kts
-│   └── src/main/
-│       ├── AndroidManifest.xml
-│       └── kotlin/com/wellnesswingman/
-│           ├── MainActivity.kt           # Main activity
-│           └── WellnessWingmanApp.kt    # Application class (Koin setup)
-├── composeApp/          # Compose UI library (shared UI components)
-│   └── src/
-│       ├── commonMain/   # Cross-platform UI code
-│       └── androidMain/  # Android-specific UI
-├── shared/              # Shared business logic (models, repos, services)
-│   └── src/
-│       ├── commonMain/   # Cross-platform code
-│       └── androidMain/  # Android-specific implementations
-└── gradle/              # Gradle wrapper and dependencies
+```properties
+polar.client.id=your-polar-client-id
+polar.broker.base.url=https://your-cloud-function-url
 ```
 
-## Quick Start - Command Line
+## Project Shape
 
-### 1. List Available Gradle Tasks
+- `androidApp/`: Android app entry point and manifest
+- `composeApp/`: shared Compose UI
+- `shared/`: shared data, domain, SQLDelight, and platform abstractions
+- `polar-oauth-broker/`: Polar OAuth broker and Terraform
+
+## Build the App
+
+From the repository root:
 
 ```bash
-cd D:\SourceCode\WellnessWingman\kotlin
-.\gradlew.bat tasks --group build
+./gradlew :androidApp:assembleDebug
 ```
 
-### 2. Build the App
+APK output:
 
-```bash
-# Debug build (faster, includes debug info)
-.\gradlew.bat :androidApp:assembleDebug
-
-# Release build (optimized, no debug info)
-.\gradlew.bat :androidApp:assembleRelease
+```text
+androidApp/build/outputs/apk/debug/androidApp-debug.apk
 ```
 
-APK will be generated at: `androidApp/build/outputs/apk/debug/androidApp-debug.apk`
+## Install and Launch
 
-### 3. Install to Emulator/Device
-
-First, make sure an emulator is running or device is connected:
+Start an emulator or connect a device, then:
 
 ```bash
-# List connected devices/emulators
-adb devices
-
-# If no emulator is running, start one (requires Android SDK)
-emulator -list-avds                    # List available emulators
-emulator -avd <avd_name> &            # Start emulator in background
-```
-
-Install the app:
-
-```bash
-# Install debug build
-.\gradlew.bat :androidApp:installDebug
-
-# Or install directly with adb
-adb install androidApp/build/outputs/apk/debug/androidApp-debug.apk
-```
-
-### 4. Run the App
-
-```bash
-# Build, install, and launch the app in one command
-.\gradlew.bat :androidApp:installDebug
+./gradlew :androidApp:installDebug
 adb shell am start -n com.wellnesswingman/.MainActivity
 ```
 
-## Using Android Studio
-
-### Initial Setup
-
-1. **Open Project**
-   - Launch Android Studio
-   - Select "Open" and navigate to `D:\SourceCode\WellnessWingman\kotlin`
-   - Wait for Gradle sync to complete (first time may take several minutes)
-
-2. **Configure SDK**
-   - File → Project Structure → SDK Location
-   - Ensure Android SDK location is set (usually `C:\Users\<username>\AppData\Local\Android\Sdk`)
-   - Ensure JDK is set to Java 17
-
-3. **Set Up Emulator**
-   - Tools → Device Manager (or AVD Manager)
-   - Click "Create Device"
-   - Recommended: Pixel 6 or similar with API 34 (Android 14)
-   - Download system image if prompted
-   - Finish setup
-
-### Running from Android Studio
-
-1. **Select Configuration**
-   - Top toolbar: Select `androidApp` from the run configuration dropdown
-   - Select your emulator device next to it
-
-2. **Run the App**
-   - Click the green "Run" button (▶) or press `Shift+F10`
-   - Or: Run → Run 'androidApp'
-   - First build will take a few minutes
-
-3. **Debug the App**
-   - Click the "Debug" button (🐞) or press `Shift+F9`
-   - Or: Run → Debug 'androidApp'
-
-### Setting Breakpoints
-
-1. Open any Kotlin file (e.g., `MainActivity.kt`)
-2. Click in the left gutter next to a line number to set a breakpoint (red dot)
-3. Run in debug mode
-4. When breakpoint hits, you can:
-   - Inspect variables in the "Variables" panel
-   - Step through code (F8 = step over, F7 = step into)
-   - Evaluate expressions (Alt+F8)
-   - View call stack
-
-### Useful Debug Configurations
-
-**Build Variants** (Bottom left or Build → Select Build Variant):
-- `debug` - Includes debug symbols, logging, slower but easier to debug
-- `release` - Optimized, minified (when enabled), no debug logging
-
-## Viewing Logs
-
-### Android Studio Logcat
-
-1. Open Logcat panel (bottom toolbar)
-2. Filter by:
-   - Package: `com.wellnesswingman`
-   - Tag: `WellnessWingman`, `Napier`, or custom tags
-   - Log level: Verbose, Debug, Info, Warn, Error
-
-### Command Line
+Useful device checks:
 
 ```bash
-# View all logs from the app
-adb logcat | grep "com.wellnesswingman"
-
-# View Napier logs (our logging library)
-adb logcat | grep "Napier"
-
-# Clear log buffer first
-adb logcat -c
+adb devices
 adb logcat
 ```
 
-## Common Gradle Commands
+## Android Studio
+
+1. Open the repository root in Android Studio.
+2. Let Gradle sync finish.
+3. Confirm the SDK path and JDK.
+4. Select the `androidApp` run configuration.
+5. Run or debug on an emulator/device.
+
+## First-Run Setup
+
+- Configure an LLM provider in Settings.
+- Add the required API key for the selected provider.
+- Grant camera, microphone, and notification permissions as needed.
+- Add Polar config to `local.properties` if you want to test OAuth and sync flows.
+
+## Notable Runtime Behaviors
+
+- `MainActivity` handles image share intents, so Android can send images directly into a pending capture flow.
+- OAuth callbacks use the `wellnesswingman://oauth/result` deep link.
+- `WellnessWingmanApp` schedules background jobs for image retention and Polar sync via WorkManager.
+- On startup, the app recovers stale processing entries and retries a pending Polar OAuth redemption if one survived process death.
+
+## Useful Commands
 
 ```bash
-# Clean build (removes all build artifacts)
-.\gradlew.bat clean
+# Clean
+./gradlew clean
 
-# Clean and rebuild everything
-.\gradlew.bat clean :androidApp:assembleDebug
+# Build everything needed for Android debug
+./gradlew :androidApp:assembleDebug
 
-# Run tests
-.\gradlew.bat :shared:test
+# Shared tests
+./gradlew :shared:desktopTest
 
-# Run tests with coverage report
-.\gradlew.bat :shared:test :shared:koverHtmlReport
-
-# Check dependencies
-.\gradlew.bat :androidApp:dependencies
-
-# Sync Gradle (if you edit build files)
-.\gradlew.bat --refresh-dependencies
+# Coverage report
+./gradlew :shared:desktopTest :shared:koverHtmlReport
 ```
 
 ## Troubleshooting
 
-### "No connected devices"
+### Java not found
 
-```bash
-# Check if emulator is running
-adb devices
+If Gradle fails with `JAVA_HOME is not set` or `java: command not found`, install JDK 17+ and export `JAVA_HOME` before running Gradle.
 
-# Restart adb if needed
-adb kill-server
-adb start-server
-adb devices
-```
+### SDK location missing
 
-### "SDK location not found"
+Create or update `local.properties`:
 
-- Create/edit `local.properties` in the kotlin directory:
-  ```properties
-  sdk.dir=C:\\Users\\<YourUsername>\\AppData\\Local\\Android\\Sdk
-  ```
-
-### "Build failed" or "Sync failed"
-
-```bash
-# Clean and retry
-.\gradlew.bat clean
-.\gradlew.bat :androidApp:assembleDebug --refresh-dependencies
-```
-
-### "Out of memory" during build
-
-Edit `gradle.properties` and increase heap size:
 ```properties
-org.gradle.jvmargs=-Xmx4g -XX:MaxMetaspaceSize=1g
+sdk.dir=/path/to/Android/Sdk
 ```
 
-### App crashes on launch
+### Polar OAuth button does nothing
 
-1. Check Logcat for crash logs
-2. Common issues:
-   - Missing API keys (OpenAI) - Check settings screen
-   - Database initialization errors - Clear app data
-   - Permission errors - Grant permissions in emulator settings
+Check both:
 
-## App Configuration
+- `polar.client.id`
+- `polar.broker.base.url`
 
-### Required Setup on First Launch
+If either is blank, the Android build will still compile, but Polar connection flows will not work.
 
-The app requires configuration before it can analyze meals:
+### Background sync is not running
 
-1. **OpenAI API Key**
-   - Launch app → Settings screen
-   - Enter your OpenAI API key
-   - Key is stored in encrypted preferences
+Verify:
 
-2. **Permissions** (will be requested on first use)
-   - Camera - for meal photo capture
-   - Microphone - for voice notes
-   - Storage - for saving photos
+- network is available
+- battery saver is not aggressively restricting WorkManager
+- the app has been launched at least once so periodic work can be enqueued
 
-### Database Location
+### App launch or processing issues
 
-SQLite database is stored at:
-- Debug: `/data/data/com.wellnesswingman/databases/wellness_wingman.db`
-- Access via: `adb shell` then `run-as com.wellnesswingman`
+Use Logcat and filter on:
 
-## Development Workflow
+- `com.wellnesswingman`
+- `Napier`
 
-### Typical Edit-Debug Cycle
-
-1. Make code changes in Android Studio
-2. Click "Run" or "Debug" (Gradle will auto-rebuild changed modules)
-3. App automatically installs and launches
-4. Test your changes
-5. Check Logcat for any errors or debug logs
-
-### Hot Reload (Compose)
-
-- Compose supports live preview of UI changes
-- Open any `@Composable` function
-- Click "Split" or "Design" mode to see preview
-- UI changes reflect immediately in preview (no rebuild needed)
-
-### Testing Individual Modules
-
-```bash
-# Test just the shared module
-.\gradlew.bat :shared:test
-
-# Test androidApp (if instrumented tests exist)
-.\gradlew.bat :androidApp:connectedDebugAndroidTest
-```
-
-## Performance Profiling
-
-In Android Studio:
-
-1. Run → Profile 'androidApp'
-2. Choose profiler:
-   - CPU - Find slow methods
-   - Memory - Find leaks
-   - Network - Monitor API calls
-   - Energy - Battery usage
-
-## Next Steps
-
-- See `TESTING.md` for E2E testing with Maestro
-- See `shared/build/reports/kover/html/index.html` for test coverage
-- Check the project README for architecture details
-
-## Useful Resources
-
-- [Kotlin Multiplatform Docs](https://kotlinlang.org/docs/multiplatform.html)
-- [Jetpack Compose Docs](https://developer.android.com/jetpack/compose)
-- [Android Debug Guide](https://developer.android.com/studio/debug)
-- [Gradle User Guide](https://docs.gradle.org/current/userguide/userguide.html)
+The app uses persistent Napier-backed logging, and diagnostics can also be shared from Settings.

--- a/TESTING.md
+++ b/TESTING.md
@@ -53,7 +53,7 @@ The current suites cover:
 - JDK 17 or newer
 - `JAVA_HOME` configured, or `java` available on `PATH`
 
-Without Java, Gradle will fail before configuration. In this workspace, `java` is currently unavailable, so the commands above could not be executed during this documentation update.
+Without Java, Gradle will fail before configuration.
 
 ## Practical Workflow
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -1,93 +1,86 @@
 # Testing Guide
 
-## Test Suite Overview
+This project’s main automated verification path is the shared desktop/unit suite plus Kover coverage reporting.
 
-WellnessWingman includes comprehensive unit tests using kotlin.test for multiplatform testing.
-
-### Test Files Created
-
-**Domain Layer Tests:**
-- `DailyTotalsCalculatorTest.kt` - Tests for nutrition totals calculation
-- `DateTimeUtilTest.kt` - Tests for date/time utility functions
-
-**Data Layer Tests:**
-- `SqlDelightTrackedEntryRepositoryTest.kt` - Repository tests with in-memory SQLite
-- `TrackedEntryTest.kt` - Data model tests
-- `MealAnalysisResultTest.kt` - JSON serialization tests for analysis results
-
-### Running Tests
-
-#### Prerequisites
-
-**Java Version Requirement:**
-- Tests require **Java 17 LTS** or **Java 21 LTS**
-- Current system has Java 25 (early access), which is not yet supported by Kotlin 2.x
-- To install Java 17:
-  - **Windows**: Download from [Adoptium](https://adoptium.net/temurin/releases/)
-  - **Using Chocolatey**: `choco install openjdk17`
-  - **Using Scoop**: `scoop install openjdk17`
-
-#### Running the Test Suite
-
-Once Java 17/21 is installed:
+## Primary Commands
 
 ```bash
-# Run all tests
-./gradlew test
+# Shared tests used in CI
+./gradlew :shared:desktopTest
 
-# Run shared module tests
-./gradlew :shared:testDebugUnitTest
+# XML report for Codecov
+./gradlew :shared:koverXmlReport
 
-# Run with coverage report (when Kover is re-enabled)
-./gradlew koverHtmlReport
+# Browsable local report
+./gradlew :shared:koverHtmlReport
+
+# Recommended local coverage pass
+./gradlew :shared:desktopTest :shared:koverHtmlReport
+
+# Full verification pass
+./gradlew check
 ```
 
-### Test Coverage
+## Test Locations
 
-Current test coverage includes:
-- ✅ Business logic (DailyTotalsCalculator)
-- ✅ Utilities (DateTimeUtil)
-- ✅ Data models and serialization
-- ✅ Repository layer with in-memory database
-- ⏳ ViewModels (TODO - requires MockK setup)
-- ⏳ Use cases/Orchestrators (TODO)
+- `shared/src/commonTest/`: shared domain, repository, serialization, Polar, LLM, migration, and media tests
+- `composeApp/src/commonTest/`: shared presentation and view-model/state logic tests
 
-### Known Issues
+## Coverage
 
-1. **Java 25 Compatibility**
-   - Kotlin 2.1.0/2.2.0 doesn't recognize Java 25
-   - Error: `java.lang.IllegalArgumentException: 25`
-   - **Solution**: Install Java 17 or 21
+- XML report: `shared/build/reports/kover/report.xml`
+- HTML report: `shared/build/reports/kover/html/index.html`
+- Current Kover verification baseline in Gradle: `25%`
+- Team target documented in repository guidance: `80%` line coverage and `70%` branch coverage for production code
 
-2. **SQLDelight Reserved Keywords**
-   - Fixed: Changed `count` column alias to `entry_count` in SQL queries
+The docs and the Gradle configuration are intentionally distinguished here: the repository guidance describes the desired target, while the current enforced Gradle minimum is still lower.
 
-3. **Gradle Wrapper**
-   - ✅ Successfully generated with Gradle 9.3.0
-   - ✅ iOS targets temporarily disabled for initial setup
-   - Can be re-enabled after Gradle/Java version stabilization
+## What Is Covered Today
 
-### Future Test Improvements
+The current suites cover:
 
-- Add ViewModel tests using Turbine for Flow testing
-- Add integration tests for AnalysisOrchestrator
-- Set up Maestro E2E tests (Task #22)
-- Re-enable Kover code coverage reporting (Task #21)
-- Add UI tests using Compose Testing framework
+- SQLDelight repository behavior
+- analysis orchestration and summary services
+- OpenAI and Gemini client behavior
+- tool registry behavior
+- nutrition-label analysis and nutrition-profile flows
+- Polar OAuth, API client, diagnostics, insights, and sync orchestration
+- image retention and data migration services
+- Compose state logic for calendar, main screen, and nutrition workflows
 
-### Dependencies
+## Environment Requirements
 
-Test dependencies are configured in `shared/build.gradle.kts`:
-- `kotlin-test` - Multiplatform test framework
-- `coroutines-test` - Testing utilities for coroutines
-- `mockk` - Mocking framework
-- `turbine` - Flow testing library
-- `sqldelight-driver-jdbc` - In-memory SQLite for tests
+- JDK 17 or newer
+- `JAVA_HOME` configured, or `java` available on `PATH`
 
-## Project Status
+Without Java, Gradle will fail before configuration. In this workspace, `java` is currently unavailable, so the commands above could not be executed during this documentation update.
 
-- **Overall Completion**: 79.2% (19/24 tasks)
-- **Phase 3 (UI Layer)**: 100% complete
-- **Phase 5 (Testing)**: Partially complete (test code written, requires Java 17/21 to run)
+## Practical Workflow
 
-See [PROGRESS.md](./PROGRESS.md) for detailed task breakdown.
+For most changes:
+
+```bash
+./gradlew :shared:desktopTest
+```
+
+Before a PR that touches shared logic:
+
+```bash
+./gradlew :shared:desktopTest :shared:koverXmlReport :shared:koverHtmlReport
+```
+
+When touching multiple modules or build logic:
+
+```bash
+./gradlew check
+```
+
+## Manual Verification Areas
+
+Automated tests do not replace manual checks for:
+
+- Android camera and share-intent capture flows
+- notification and foreground-service behavior
+- Polar OAuth browser redirect flow
+- WorkManager-triggered image retention and Polar sync
+- export/import UX and diagnostics sharing

--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -2,6 +2,7 @@ import java.util.Properties
 
 plugins {
     alias(libs.plugins.android.application)
+    alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.compose.compiler)
 }
 

--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -2,7 +2,6 @@ import java.util.Properties
 
 plugins {
     alias(libs.plugins.android.application)
-    alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.compose.compiler)
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,11 +8,3 @@ plugins {
     alias(libs.plugins.sqldelight) apply false
     // alias(libs.plugins.kover) // Disabled for now - can be configured later
 }
-
-allprojects {
-    repositories {
-        google()
-        mavenCentral()
-        maven("https://maven.pkg.jetbrains.space/public/p/compose/dev")
-    }
-}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,33 +1,122 @@
 # WellnessWingman Architecture
 
-## Purpose & Scope
-WellnessWingman is a Kotlin Multiplatform application built around a shared data and domain layer, a Compose Multiplatform UI module, and platform entry points for Android and iOS. The active repository targets the Kotlin/Gradle stack only; any prior MAUI implementation is historical and no longer part of the supported architecture.
+## Overview
 
-## Active Modules
-- `shared/`: shared domain models, SQLDelight schema, repositories, platform abstractions, and business workflows.
-- `composeApp/`: shared Compose UI, navigation, screen models, and reusable presentation components.
-- `androidApp/`: Android application entry point, manifest, and Android-specific wiring.
-- `iosApp/`: iOS host application that integrates the shared Kotlin framework.
+WellnessWingman is an Android-first Kotlin Multiplatform application organized around a shared `shared/` module, a shared Compose UI module, and an Android app shell. The repository also contains an `iosApp/` host project and a standalone Polar OAuth broker backend.
 
-## Layered Structure
-- **UI Layer**: Compose screens in `composeApp/src/commonMain/kotlin/com/wellnesswingman/ui/` render entry capture, calendar views, summaries, and settings. Android-specific launch code lives in `androidApp/src/main/kotlin/com/wellnesswingman/`.
-- **Domain Layer**: Shared services in `shared/src/commonMain/kotlin/com/wellnesswingman/domain/` coordinate capture state, analysis orchestration, summaries, migration, and navigation.
-- **Data Layer**: Repositories in `shared/src/commonMain/kotlin/com/wellnesswingman/data/repository/` persist entries, analyses, summaries, and settings using SQLDelight-backed storage.
-- **Platform Layer**: `expect`/`actual` implementations in the source-set-specific `shared/src/*Main/` trees provide filesystem, camera, background execution, audio, sharing, and ZIP support.
+## Modules
 
-## Data Flow
-1. Platform capture services create or import raw assets and metadata.
-2. Shared repositories persist `TrackedEntry` records and related analysis state via SQLDelight.
-3. Domain services orchestrate LLM analysis, status updates, stale-entry recovery, and summary generation.
-4. Compose screens consume repository and domain outputs to render the current state across platforms.
+- `shared/`
+  - shared models, repositories, SQLDelight schemas/migrations, platform abstractions, LLM clients, Polar sync logic, summary services, media retention, and export/import support
+- `composeApp/`
+  - shared Compose UI, Voyager navigation, screen models, and presentation logic
+- `androidApp/`
+  - Android manifest, application startup, Koin bootstrap, deep-link/share-intent handling, and WorkManager jobs
+- `iosApp/`
+  - Xcode host app for the shared Kotlin framework
+- `polar-oauth-broker/`
+  - Python broker plus Terraform for Polar OAuth callback, session redemption, and token refresh
+
+## Layers
+
+### Data layer
+
+Lives mostly under `shared/src/commonMain/kotlin/com/wellnesswingman/data/`.
+
+Responsibilities:
+
+- SQLDelight-backed repositories for entries, analyses, daily summaries, weekly summaries, weight history, nutritional profiles, and Polar sync state
+- app settings and secure-token storage abstractions
+- Polar API client and OAuth repository
+- serialized models for LLM, export/import, and Polar payloads
+
+### Domain layer
+
+Lives mostly under `shared/src/commonMain/kotlin/com/wellnesswingman/domain/`.
+
+Responsibilities:
+
+- analysis orchestration for meal, sleep, and exercise entries
+- daily and weekly summary generation
+- LLM provider abstraction and tool registry
+- nutrition-label analysis
+- Polar sync orchestration, diagnostics, and insight generation
+- stale-entry recovery, pending capture state, data migration, navigation helpers, and image retention
+
+### UI layer
+
+Lives in `composeApp/src/commonMain/kotlin/com/wellnesswingman/ui/`.
+
+Responsibilities:
+
+- entry list and entry-detail flows
+- calendar/day/week/year views
+- daily summary presentation
+- sectioned settings navigation
+- Polar settings
+- nutritional profile management and nutrition-label scanning
+- weight history logging
+- diagnostics and data-management screens
+
+### Platform layer
+
+Platform abstractions are defined in `shared/src/commonMain/kotlin/com/wellnesswingman/platform/` and implemented in source-set-specific code.
+
+Current Android-specific responsibilities include:
+
+- secure settings storage
+- camera and file handling
+- audio recording
+- diagnostics/log sharing
+- WorkManager background jobs
+- deep-link and share-intent integration
 
 ## Dependency Injection
-Koin modules under `shared/src/commonMain/kotlin/com/wellnesswingman/di/` define the shared dependency graph. Platform modules contribute the required actual implementations, and application entry points load the combined module set during startup.
 
-## Storage & Analysis
-- SQLDelight schemas and migrations live under `shared/src/commonMain/sqldelight/com/wellnesswingman/db/`.
-- LLM provider abstractions live under `shared/src/commonMain/kotlin/com/wellnesswingman/domain/llm/`.
-- Sensitive configuration must stay in secure platform-managed storage and should not be written to plaintext files or logs.
+Koin modules in `shared/src/commonMain/kotlin/com/wellnesswingman/di/` define the shared graph:
+
+- `dataModule`: repositories, database, settings-backed storage, Polar repository/client
+- `domainModule`: orchestrators, summaries, tool registry, migration, Polar services, image retention, and background-analysis services
+- `platformModule`: platform-specific implementations
+
+`androidApp` adds Android startup wiring and supplies `PolarOAuthConfig` from `local.properties`-backed `BuildConfig` fields.
+
+## Persistence
+
+SQLDelight schemas and migrations live under:
+
+`shared/src/commonMain/sqldelight/com/wellnesswingman/db/`
+
+The database version is currently `7`. Migrations exist for versions:
+
+- `1.sqm`
+- `2.sqm`
+- `4.sqm`
+- `5.sqm`
+- `6.sqm`
+- `7.sqm`
+
+## Android Runtime Flow
+
+At app startup:
+
+1. `WellnessWingmanApp` initializes Napier persistent logging and Koin.
+2. stale processing entries are recovered
+3. any pending Polar OAuth redemption is retried
+4. periodic WorkManager jobs are enqueued for image retention and Polar sync
+
+At activity level:
+
+- `MainActivity` accepts Android image-share intents and converts them into pending captures
+- OAuth callbacks arrive through `wellnesswingman://oauth/result`
+- the Compose app launches into `MainScreen` and navigates from there via Voyager
+
+## Current Constraints
+
+- Android is the practical first-class target in this repo today
+- Gradle iOS targets are commented out in build scripts pending a compatible Kotlin/Gradle path
+- some operational flows are intentionally Android-only at runtime, especially WorkManager scheduling
 
 ## Historical Context
-`MIGRATION_ANALYSIS.md` remains in the repository as archival documentation explaining the move from the former .NET MAUI implementation to Kotlin Multiplatform. It is not an operational guide for the current codebase.
+
+`MIGRATION_ANALYSIS.md` remains as archival documentation of the earlier MAUI-to-Kotlin migration. It is not a guide to the currently supported runtime architecture.

--- a/docs/POLAR.md
+++ b/docs/POLAR.md
@@ -1,182 +1,120 @@
 # Polar Integration
 
 ## Overview
-WellnessWingman integrates with [Polar](https://www.polar.com/) fitness devices via Polar's AccessLink API. Authentication uses OAuth 2.0 with a server-side broker that keeps the client secret off the mobile device.
 
-## Architecture
+WellnessWingman integrates with Polar AccessLink through an OAuth broker that keeps the Polar client secret off-device. The current implementation covers:
 
-```mermaid
-sequenceDiagram
-    participant User
-    participant App as Android App
-    participant Browser as Chrome Custom Tab
-    participant Polar as Polar Auth
-    participant Broker as Cloud Function
-    participant Firestore
+- Android OAuth connect/disconnect flow
+- broker-backed session redemption and refresh
+- shared Polar API client and DTO mapping
+- persisted sync checkpoints and metric storage
+- foreground refresh orchestration
+- Android periodic background sync through WorkManager
+- summary-facing Polar insight generation
 
-    User->>App: Tap "Connect Polar"
-    App->>Browser: Open Polar authorization URL
-    Browser->>Polar: User consents
-    Polar->>Broker: GET /oauth/callback?code=...&state=...
-    Broker->>Polar: Exchange code for tokens (Basic auth)
-    Polar-->>Broker: access_token, refresh_token
-    Broker->>Broker: Encrypt tokens (AES-256-GCM)
-    Broker->>Firestore: Store encrypted session
-    Broker-->>Browser: Redirect wellnesswingman://oauth/result?session=<id>
-    Browser->>App: Deep link → MainActivity.onNewIntent
-    App->>App: PendingOAuthResultStore.deliver()
-    App->>Broker: POST /oauth/redeem {session_id}
-    Broker->>Firestore: Read & mark redeemed
-    Broker->>Broker: Decrypt tokens
-    Broker-->>App: {tokens}
-    App->>App: Store in EncryptedSharedPreferences
-    App->>User: UI shows "Connected"
-```
+This document reflects the post-March-2026 implementation state.
 
 ## Components
 
-### Backend: `polar-oauth-broker/`
+### Android app
 
-A Python Cloud Function (Google Cloud Functions gen2) with four routes:
+- launches the Polar consent flow in a browser/custom tab
+- receives `wellnesswingman://oauth/result` deep links
+- stores pending OAuth state so redemption can survive process death
+- stores Polar tokens through the app settings repository
+- schedules a periodic `PolarSyncWorker` on Android
 
-| Route | Method | Purpose |
-|-------|--------|---------|
-| `/oauth/callback` | GET | Polar redirects here after user consent. Exchanges authorization code for tokens using Basic auth (Polar v4), encrypts tokens with AES-256-GCM, stores in Firestore, redirects to app via custom scheme. |
-| `/oauth/redeem` | POST | App sends `{session_id}`. One-time pickup: decrypts tokens, returns JSON, marks session redeemed. Returns 410 on replay. |
-| `/oauth/refresh` | POST | Stateless proxy: app sends `{refresh_token}`, broker forwards to Polar with client credentials, returns new tokens. No Firestore involved. |
-| `/.well-known/assetlinks.json` | GET | Placeholder for future App Links verification. |
+### Shared code
 
-**Infrastructure** is managed with Terraform (`polar-oauth-broker/infra/`):
-- Cloud Function gen2 (Python 3.12, 256MB, min-instances=0)
-- Firestore with TTL policy on `oauth_sessions` (10-minute expiry)
-- Secret Manager for `polar-client-secret` and `polar-oauth-session-key`
-- Dedicated service account with `datastore.user` + `secretmanager.secretAccessor`
-- Public invocation IAM (Polar must reach the callback)
+- `PolarOAuthRepository`: redeem and refresh token flows
+- `PolarApiClient`: AccessLink requests and DTO mapping
+- `PolarSyncRepository`: SQLDelight-backed persistence for metrics and checkpoints
+- `PolarSyncOrchestrator`: refresh logic and sync coordination
+- `PolarInsightService`: transforms synced data into summary-friendly context
 
-### Android Client
+### Broker backend
 
-**Token storage:** `EncryptedSharedPreferences` via `AppSettingsRepository` methods (`getPolarAccessToken`, `setPolarRefreshToken`, etc.). All Polar keys use the `polar_` prefix.
+`polar-oauth-broker/` contains:
 
-**Deep link flow:**
-1. `MainActivity` has `singleTask` launch mode and an intent-filter for `wellnesswingman://oauth/result`
-2. `handleOAuthDeepLink()` extracts `session` and `state` parameters
-3. Delivers to `PendingOAuthResultStore` (in-memory `StateFlow` singleton)
-4. `PolarSettingsViewModel` observes the store and auto-triggers session redemption
+- `main.py`: callback, redeem, refresh, and assetlinks routes
+- `crypto.py`: token encryption helpers
+- `infra/`: Terraform for Cloud Function, Firestore, Secret Manager, and IAM
 
-**Browser launch:** `OAuthBrowserLauncher` is an `expect`/`actual` composable. Android uses `CustomTabsIntent`, desktop is a no-op.
+## OAuth Flow
 
-## Configuration
+1. User taps connect in Polar settings.
+2. Android opens the Polar authorization URL.
+3. Polar redirects to the broker callback.
+4. The broker exchanges the code for tokens, encrypts them, and stores a short-lived session.
+5. The broker redirects back to `wellnesswingman://oauth/result?...`.
+6. `MainActivity` delivers the pending result.
+7. `PolarOAuthRepository` redeems the one-time session and persists the tokens locally.
 
-### Local development
+If the app process dies before redemption completes, `WellnessWingmanApp` retries redemption on the next launch while the broker session is still valid.
 
-Add to `local.properties` (see `local.properties.example`):
+## Local Configuration
+
+Add these to `local.properties`:
 
 ```properties
 polar.client.id=your-polar-client-id
 polar.broker.base.url=https://your-cloud-function-url
 ```
 
-These become `BuildConfig.POLAR_CLIENT_ID` and `BuildConfig.POLAR_BROKER_BASE_URL`, provided to `PolarOAuthConfig` via Koin in `WellnessWingmanApp`.
+These values become Android `BuildConfig` fields and are injected into `PolarOAuthConfig`.
 
-### Backend deployment
+## Backend Deployment
 
 ```bash
 cd polar-oauth-broker/infra
 cp terraform.tfvars.example terraform.tfvars
-# Edit terraform.tfvars with real values
 terraform init
 terraform apply
 ```
 
-After initial apply, update the secret values:
+After the first apply, upload real secret values:
 
 ```bash
 echo -n "real-client-secret" | gcloud secrets versions add polar-client-secret --data-file=-
 python3 -c "import os; print(os.urandom(32).hex())" | gcloud secrets versions add polar-oauth-session-key --data-file=-
 ```
 
-## Verification
+## Sync Behavior
 
-1. **Backend curl test:** Deploy function → open Polar auth URL in browser → consent → grab `session_id` from redirect → `curl -X POST <url>/oauth/redeem -H 'Content-Type: application/json' -d '{"session_id":"<id>"}'` → tokens returned → repeat → 410 Gone
-2. **Migration test:** Install current app (plain prefs), then install updated build → verify settings preserved in encrypted prefs
-3. **Deep link test:** `adb shell am start -a android.intent.action.VIEW -d "wellnesswingman://oauth/result?session=test&state=abc"` → verify `PendingOAuthResultStore` receives it
-4. **End-to-end:** Tap Connect → Chrome Custom Tab → Polar consent → redirect → app shows "Connected" with user ID
-5. **Disconnect:** Tap Disconnect → tokens cleared → UI shows "Connect" button
+Current shipped behavior:
 
-## AccessLink API v4 — Endpoint Features
+- Polar data is stored in dedicated SQLDelight tables, not in `TrackedEntry`
+- checkpoint state is tracked independently for each sync domain
+- the app performs a foreground refresh when the latest successful sync is stale
+- Android also schedules a periodic background refresh every 12 hours when connected to the network
 
-The Polar AccessLink v4 data endpoints support an optional `features` query parameter
-that controls which data is included in the response. Without `features`, most endpoints
-return empty or minimal stubs. This has significant implications for the sync orchestrator.
+Non-Android platforms do not currently ship an equivalent background scheduler in this repo.
 
-### Currently implemented
+## AccessLink Endpoint Notes
 
-| Endpoint | Features requested | Max range | Notes |
-|----------|-------------------|-----------|-------|
-| `activity/list` | `samples` | 28 days | Step samples as dense time-series (1-min intervals). Without `samples`, `activitiesPerDevice` is empty. |
-| `sleeps` | `sleep-result`, `sleep-evaluation`, `sleep-score` | **1 day** | Returns hypnogram timing, phase durations, quality metrics, and Polar sleep scores. Without features, returns bare `{sleepDate}` stubs with no data. |
-| `training-sessions/list` | _(none)_ | 90 days | Base response already includes HR, calories, distance, duration, recovery time, sport ID. No features needed for the core wellness data. |
-| `nightly-recharge-results` | _(none — no features param)_ | 28 days | Returns HRV (RMSSD, R-R interval), ANS status, baselines, and recovery indicators. |
-| `user/account-data` | _(none — no features param)_ | N/A | Profile endpoint, no date range. Returns physical info (resting HR, VO2max, weight, height, sleep goal). |
+Implemented or actively used today:
 
-### Training sessions — deferred features
+- `activity/list` with `samples`
+- `sleeps` with sleep-related feature flags
+- `training-sessions/list`
+- `nightly-recharge-results`
+- `user/account-data`
 
-The training-sessions endpoint supports 12 optional features. When any features are
-requested, the max date range drops to **1 day**, forcing day-by-day pagination. The base
-response (no features) is already rich enough for the wellness dashboard, so we defer
-these features to avoid the pagination complexity during initial sync.
+The current architecture already accounts for the fact that some endpoints support broader date windows while others require day-by-day sync behavior.
 
-| Feature | What it adds | Wellness value | Why deferred |
-|---------|-------------|----------------|--------------|
-| `training-load-report` | `cardioLoad`, `muscleLoad`, interpretations, `perceivedLoad`, `sessionRpe` | **High** — recovery/strain tracking, like Whoop strain score | 1-day limit. Best added when sync orchestrator supports day-by-day pagination. |
-| `zones` | HR/power/speed zone distribution with `inZone` time (ms) per zone | **High** — shows training intensity distribution | 1-day limit. Large payload per session. |
-| `statistics` | min/avg/max for altitude, cadence, HR, power, speed | Medium — summary stats already partially available in base response (`hrAvg`, `hrMax`) | 1-day limit. Partially redundant with base fields. |
-| `samples` | Dense time-series (HR, speed, altitude, etc.) | Low for dashboard — useful for detailed session replay | 1-day limit. Very large payload. |
-| `laps` | Lap splits with per-lap stats | Low | Niche use case. |
-| `hill-splits` | Uphill/downhill segment analysis | Low | Niche use case. |
-| `routes` | GPS track data | Low for wellness | Large payload, niche. |
-| `test-results` | Fitness test results (orthostatic, etc.) | Medium | Rare — only present on test sessions. |
-| `pause-times` | Pause/resume timestamps | Low | |
-| `strength-training-results` | Sets, reps, weights per exercise | Medium for strength athletes | Niche. |
-| `comments` | User notes on sessions | Low | |
-| `physical-info` | Profile info per session | Low — available via `user/account-data` | Redundant. |
+## What Changed In March 2026
 
-**Recommendation:** When the sync orchestrator is built, add `training-load-report` and
-`zones` as a priority. The cardio/muscle load data combined with HR zone distribution
-gives a complete training strain picture. The sync orchestrator will already need
-day-by-day pagination for sleep, so extending it to training sessions is incremental.
+- `#118`: initial broker-backed Polar OAuth flow
+- `#119`: shared Polar API client and DTO mapping
+- `#120`: sync persistence and refresh orchestration
+- `#121`: Polar insight bridge and follow-up day-detail support
 
-### Activity — deferred features
+Earlier documentation that said there was no sync orchestrator or no Android background sync is now outdated.
 
-| Feature | What it adds | Why deferred |
-|---------|-------------|--------------|
-| `activity-target` | Daily MET goal (`minDailyMetGoal`) | Low priority — can be derived from profile. |
-| `physical-information` | Profile data repeated per day | Redundant — use `user/account-data` instead. |
+## Verification Checklist
 
-### Sync orchestrator implications
-
-The `features` parameter creates a two-tier pagination model:
-
-- **Bulk sync** (activity, training, nightly recharge): multi-day ranges, fewer API calls
-- **Detail sync** (sleep, future training features): 1-day max, requires day-by-day loop
-
-The sync orchestrator should handle this transparently, batching bulk endpoints and
-iterating daily for detail endpoints. Rate limiting (Polar enforces 429) should use
-exponential backoff.
-
-## Scope Boundaries (Milestone 1)
-
-Not included in the initial implementation:
-- No sync orchestrator / WorkManager / Polar data fetching
-- No App Links verification (custom scheme only)
-- No iOS support
-- No Cloud Armor / rate limiting
-- No `/start` endpoint (state generated on-device)
-
-## Current Sync Policy
-
-- Polar API data is persisted in dedicated SQLDelight tables (`PolarMetricRecord`, `PolarSyncCheckpoint`) instead of `TrackedEntry`.
-- Sync checkpoints are tracked independently for `ACTIVITY`, `SLEEP`, `TRAINING`, `NIGHTLY_RECHARGE`, and `USER_PROFILE`.
-- The app performs an automatic foreground refresh on app entry when the latest successful sync is older than 6 hours.
-- Android also schedules a periodic WorkManager refresh every 12 hours when network is available.
-- Non-Android platforms currently refresh only while the app is open; no background scheduler ships there yet.
+- connect from Polar settings and complete the browser redirect
+- confirm the app reports a connected state
+- confirm sync data persists across app restarts
+- verify `PolarSyncWorker` is scheduled after app launch
+- verify disconnect clears local Polar token state

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,6 +2,7 @@
 # Keep Gradle conservative, but leave enough heap for Kotlin compilation.
 org.gradle.jvmargs=-Xmx1536m -Dfile.encoding=UTF-8
 org.gradle.parallel=false
+org.gradle.configureondemand=true
 org.gradle.workers.max=1
 org.gradle.caching=true
 org.gradle.configuration-cache=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,8 +1,13 @@
 # Project-wide Gradle settings
-org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
-org.gradle.parallel=true
+# Keep Gradle within the memory envelope of small CI/dev machines.
+org.gradle.jvmargs=-Xmx768m -Dfile.encoding=UTF-8
+org.gradle.parallel=false
 org.gradle.caching=true
+org.gradle.configuration-cache=true
+org.gradle.configuration-cache.parallel=true
+org.gradle.configuration-cache.problems=warn
 org.gradle.java.installations.auto-download=true
+kotlin.daemon.jvmargs=-Xmx512m
 
 # Kotlin
 kotlin.code.style=official
@@ -22,6 +27,8 @@ android.enableAppCompileTimeRClass=false
 android.usesSdkInManifest.disallowed=false
 android.uniquePackageNames=false
 android.dependency.useConstraints=true
+android.dependency.excludeLibraryComponentsFromConstraints=true
+android.generateSyncIssueWhenLibraryConstraintsAreEnabled=false
 android.r8.strictFullModeForKeepRules=false
 android.r8.optimizedResourceShrinking=false
 android.builtInKotlin=false

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,13 +1,14 @@
 # Project-wide Gradle settings
-# Keep Gradle within the memory envelope of small CI/dev machines.
-org.gradle.jvmargs=-Xmx768m -Dfile.encoding=UTF-8
+# Keep Gradle conservative, but leave enough heap for Kotlin compilation.
+org.gradle.jvmargs=-Xmx1536m -Dfile.encoding=UTF-8
 org.gradle.parallel=false
+org.gradle.workers.max=1
 org.gradle.caching=true
 org.gradle.configuration-cache=true
 org.gradle.configuration-cache.parallel=true
 org.gradle.configuration-cache.problems=warn
 org.gradle.java.installations.auto-download=true
-kotlin.daemon.jvmargs=-Xmx512m
+kotlin.daemon.jvmargs=-Xmx1024m
 
 # Kotlin
 kotlin.code.style=official

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,6 +18,8 @@ kotlin.jvm.target.validation.mode=warning
 # Android
 android.useAndroidX=true
 android.nonTransitiveRClass=true
+android.builtInKotlin=false
+android.newDsl=false
 
 # Compose
 org.jetbrains.compose.experimental.uikit.enabled=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -21,15 +21,7 @@ android.nonTransitiveRClass=true
 
 # Compose
 org.jetbrains.compose.experimental.uikit.enabled=true
-android.defaults.buildfeatures.resvalues=true
-android.sdk.defaultTargetSdkToCompileSdkIfUnset=false
-android.enableAppCompileTimeRClass=false
-android.usesSdkInManifest.disallowed=false
 android.uniquePackageNames=false
 android.dependency.useConstraints=true
-android.dependency.excludeLibraryComponentsFromConstraints=true
 android.generateSyncIssueWhenLibraryConstraintsAreEnabled=false
 android.r8.strictFullModeForKeepRules=false
-android.r8.optimizedResourceShrinking=false
-android.builtInKotlin=false
-android.newDsl=false

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,5 +1,4 @@
 rootProject.name = "WellnessWingman"
-enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")
 
 pluginManagement {
     repositories {

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -150,27 +150,29 @@ sqldelight {
 }
 
 pluginManager.withPlugin("org.jetbrains.kotlinx.kover") {
-    configure<org.jetbrains.kotlinx.kover.gradle.plugin.dsl.KoverProjectExtension> {
-        reports {
-            filters {
-                excludes {
-                    // Exclude generated code
-                    packages("com.wellnesswingman.db")
+    extensions.configure("kover") {
+        withGroovyBuilder {
+            "reports" {
+                "filters" {
+                    "excludes" {
+                        // Exclude generated code
+                        "packages"("com.wellnesswingman.db")
 
-                    // Exclude platform-specific implementations (tested via integration tests)
-                    packages("com.wellnesswingman.platform")
+                        // Exclude platform-specific implementations (tested via integration tests)
+                        "packages"("com.wellnesswingman.platform")
 
-                    // Exclude DI modules (simple wiring, no logic)
-                    classes("*Module*")
+                        // Exclude DI modules (simple wiring, no logic)
+                        "classes"("*Module*")
+                    }
                 }
-            }
 
-            verify {
-                rule {
-                    // Current baseline: 25%
-                    // TODO: Increase threshold as more tests are added
-                    // Target: 70%+ for production code
-                    minBound(25)
+                "verify" {
+                    "rule" {
+                        // Current baseline: 25%
+                        // TODO: Increase threshold as more tests are added
+                        // Target: 70%+ for production code
+                        "minBound"(25)
+                    }
                 }
             }
         }

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -3,7 +3,13 @@ plugins {
     alias(libs.plugins.kotlin.serialization)
     alias(libs.plugins.android.library)
     alias(libs.plugins.sqldelight)
-    alias(libs.plugins.kover)
+    alias(libs.plugins.kover) apply false
+}
+
+if (gradle.startParameter.taskNames.any { taskName ->
+        taskName.contains("kover", ignoreCase = true)
+    }) {
+    apply(plugin = "org.jetbrains.kotlinx.kover")
 }
 
 kotlin {
@@ -143,27 +149,29 @@ sqldelight {
     }
 }
 
-kover {
-    reports {
-        filters {
-            excludes {
-                // Exclude generated code
-                packages("com.wellnesswingman.db")
+pluginManager.withPlugin("org.jetbrains.kotlinx.kover") {
+    configure<org.jetbrains.kotlinx.kover.gradle.plugin.dsl.KoverProjectExtension> {
+        reports {
+            filters {
+                excludes {
+                    // Exclude generated code
+                    packages("com.wellnesswingman.db")
 
-                // Exclude platform-specific implementations (tested via integration tests)
-                packages("com.wellnesswingman.platform")
+                    // Exclude platform-specific implementations (tested via integration tests)
+                    packages("com.wellnesswingman.platform")
 
-                // Exclude DI modules (simple wiring, no logic)
-                classes("*Module*")
+                    // Exclude DI modules (simple wiring, no logic)
+                    classes("*Module*")
+                }
             }
-        }
 
-        verify {
-            rule {
-                // Current baseline: 25%
-                // TODO: Increase threshold as more tests are added
-                // Target: 70%+ for production code
-                minBound(25)
+            verify {
+                rule {
+                    // Current baseline: 25%
+                    // TODO: Increase threshold as more tests are added
+                    // Target: 70%+ for production code
+                    minBound(25)
+                }
             }
         }
     }

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -150,7 +150,7 @@ sqldelight {
 }
 
 pluginManager.withPlugin("org.jetbrains.kotlinx.kover") {
-    extensions.configure("kover") {
+    extensions.findByName("kover")?.apply {
         withGroovyBuilder {
             "reports" {
                 "filters" {


### PR DESCRIPTION
## Summary
- carry forward the documentation refresh from the prior PR branch
- optimize Gradle startup for low-spec environments by reducing JVM pressure and enabling configuration cache
- make Kover opt-in so plain `:shared:desktopTest` does not pay coverage configuration cost

## Validation
- attempted `./gradlew :shared:desktopTest` on this workspace with Java 17 available
- build still remained configuration-bound on this e2-micro environment, so no successful task execution result to report from here
