### PR TITLE
Auto-increment Android versionCode from git commit count

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          # Fetch full history so `git rev-list --count HEAD` yields the true
+          # commit count for the Android versionCode (default shallow clone -> 1).
+          fetch-depth: 0
 
       - uses: actions/setup-java@v4
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -71,6 +71,7 @@ tmp/
 memory/
 
 # Local tooling
+mempalace.yaml
 
 # Tooling
 healthhelper_design.db3

--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -16,19 +16,18 @@ val localProps = Properties().apply {
 // APK has fewer commits -> a lower versionCode -> the OS refuses to silently reinstall it
 // over a newer build. Falls back to 1 when git history is unavailable (source archive / CI
 // shallow clone).
-fun gitCommitCount(): Int = try {
-    val process = ProcessBuilder("git", "rev-list", "--count", "HEAD")
-        .directory(rootProject.projectDir)
-        .redirectErrorStream(true)
-        .start()
-    val count = process.inputStream.bufferedReader().use { it.readText() }.trim().toIntOrNull()
-    process.waitFor()
-    count ?: 1
+//
+// Uses Gradle's providers.exec API so the git output is tracked as a build input and the
+// Configuration Cache is correctly invalidated when the commit count changes.
+val computedVersionCode = try {
+    providers.exec {
+        commandLine("git", "rev-list", "--count", "HEAD")
+        workingDir = rootProject.projectDir
+        isIgnoreExitValue = true
+    }.standardOutput.asText.map { it.trim().toIntOrNull() ?: 1 }.get()
 } catch (e: Exception) {
     1
 }
-
-val computedVersionCode = gitCommitCount()
 
 android {
     namespace = "com.wellnesswingman"

--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -11,6 +11,25 @@ val localProps = Properties().apply {
     if (f.exists()) load(f.inputStream())
 }
 
+// Derive a monotonic versionCode from the git commit count so each build supersedes
+// the last. This restores Android's downgrade protection: an older (e.g. backup-restored)
+// APK has fewer commits -> a lower versionCode -> the OS refuses to silently reinstall it
+// over a newer build. Falls back to 1 when git history is unavailable (source archive / CI
+// shallow clone).
+fun gitCommitCount(): Int = try {
+    val process = ProcessBuilder("git", "rev-list", "--count", "HEAD")
+        .directory(rootProject.projectDir)
+        .redirectErrorStream(true)
+        .start()
+    val count = process.inputStream.bufferedReader().use { it.readText() }.trim().toIntOrNull()
+    process.waitFor()
+    count ?: 1
+} catch (e: Exception) {
+    1
+}
+
+val computedVersionCode = gitCommitCount()
+
 android {
     namespace = "com.wellnesswingman"
     compileSdk = 34
@@ -19,7 +38,7 @@ android {
         applicationId = "com.wellnesswingman"
         minSdk = 26
         targetSdk = 34
-        versionCode = 1
+        versionCode = computedVersionCode
         versionName = "1.0.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"


### PR DESCRIPTION
## Context

The installed debug app was silently reverted from a build at SQLDelight schema **v8** to an older build at schema **v6** (an Android OS-update restore flow reinstalled an older backed-up APK). The app then crashed on launch with `cannot downgrade the database from 8 to 6`.

Root cause of *why the silent backward swap was possible*: the Android package `versionCode` was hard-coded to `1` and never changed. Android's downgrade protection (`INSTALL_FAILED_VERSION_DOWNGRADE`) only fires when `versionCode` actually increments — with a constant `1`, every APK looks identical to the OS, so an older APK can replace a newer one in either direction while keeping the data sandbox. Old code + newer DB file = the crash.

## Change

Derive `versionCode` from the git commit count (`git rev-list --count HEAD`) so each build supersedes the last. A restored older APK now has a strictly lower `versionCode` and is rejected as a downgrade instead of silently swapped in.

- `androidApp/build.gradle.kts`: inline `gitCommitCount()` helper (matching the existing `localProps` style), with a fallback to `1` when git history is unavailable (source archive / CI shallow clone). `versionName` left at `"1.0.0"`.
- `.gitignore`: ignore the local-tooling `mempalace.yaml`.

## Notes / trade-offs

- Only `androidApp` (the application module) needs this; library modules have no install-relevant `versionCode`.
- Plain commit count is a flat monotonic build number — it solves the rollback case (a months-old backup APK has far fewer commits) but carries no major-version precedence. If parallel release branches ever appear, switch to a positionally-weighted scheme (`major*10^7 + minor*10^5 + patch*10^3 + build`).

## Verification

- `git rev-list --count HEAD` → 192
- `./gradlew :androidApp:assembleDebug` → BUILD SUCCESSFUL
- Merged manifest carries `android:versionCode="192"`
- `./gradlew :androidApp:testDebugUnitTest` → NO-SOURCE (module has no unit tests; suites live in `shared/commonTest`, unaffected by a build-config change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
